### PR TITLE
feat: add main branch protection hook for Claude Code

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -6,7 +6,9 @@
 
 - コンベンショナルコミット形式を使用: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
 - コミットメッセージは英語で記述
-- **IMPORTANT**: main/masterブランチへの直接コミットは指示もしくは許可がない限り禁止
+- **CRITICAL - MANDATORY RULE**: main/masterブランチへの直接コミットは絶対に禁止。ユーザーが明示的に「mainに直接コミットしてよい」と指示した場合のみ例外とする
+- コミット前に必ず `git branch --show-current` で現在のブランチを確認すること
+- main/masterにいる場合は、まずフィーチャーブランチを作成してからコミットすること
 
 ## GitHub CLI (`gh`)
 

--- a/claude/hooks/protect-main-branch.sh
+++ b/claude/hooks/protect-main-branch.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Prevent git commit on main/master branch.
+# Used as a Claude Code PreToolUse hook for the Bash tool.
+# Exit code 2 blocks the tool execution and shows stderr to Claude.
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only check git commit commands
+if ! echo "$COMMAND" | grep -qE '(^|\s|&&|\||\;)git\s+commit(\s|$)'; then
+  exit 0
+fi
+
+# Determine the working directory from hook input, fallback to CLAUDE_PROJECT_DIR
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD="${CWD:-$CLAUDE_PROJECT_DIR}"
+
+if [ -z "$CWD" ]; then
+  exit 0
+fi
+
+BRANCH=$(git -C "$CWD" symbolic-ref --short HEAD 2>/dev/null || true)
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  echo "BLOCKED: Direct commit to '$BRANCH' branch is not allowed. Create a feature branch first." >&2
+  exit 2
+fi
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -67,6 +67,17 @@
     "playwright"
   ],
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/protect-main-branch.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,18 @@ ln -snfv "$DIR"/claude/CLAUDE.md "$HOME"/.claude/CLAUDE.md
 ln -snfv "$DIR"/claude/mcp.json "$HOME"/.claude/mcp.json
 ln -snfv "$DIR"/claude/statusline.sh "$HOME"/.claude/statusline.sh
 
+# claude hooks
+mkdir -p "$HOME"/.claude/hooks
+if [ -d "$DIR"/claude/hooks ]; then
+    for hook_file in "$DIR"/claude/hooks/*.sh; do
+        if [ -f "$hook_file" ]; then
+            hook_name=$(basename "$hook_file")
+            ln -snfv "$hook_file" "$HOME/.claude/hooks/$hook_name"
+            chmod +x "$HOME/.claude/hooks/$hook_name"
+        fi
+    done
+fi
+
 # claude skills
 mkdir -p "$HOME"/.claude/skills
 if [ -d "$DIR"/claude/skills ]; then


### PR DESCRIPTION
## Summary
- mainブランチへの直接コミットを防止するPreToolUseフックを追加
- CLAUDE.mdのGit Workflowルールを強化（CRITICAL - MANDATORY RULEに格上げ）
- install.shにhooksディレクトリのシンボリックリンク作成処理を追加

## Test plan
- [ ] `install.sh` を実行してhooksが正しくリンクされることを確認
- [ ] mainブランチでgit commitを実行した際にフックがブロックすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)