### PR TITLE
chore: set auto as default permission mode

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,6 +3,7 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
+    "defaultMode": "auto",
     "allow": [
       "Read(**)",
       "Write(src/**)",


### PR DESCRIPTION
## Summary
- `~/.claude/settings.json` の `permissions.defaultMode` に `"auto"` を設定
- 全プロジェクトでautoモードがデフォルトになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)