### PR TITLE
chore: add skipAutoPermissionPrompt to enable auto mode permanently

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -169,6 +169,7 @@
       }
     }
   },
+  "skipAutoPermissionPrompt": true,
   "toolSettings": {
     "bash": {
       "timeout": 300000


### PR DESCRIPTION
## Summary
- `skipAutoPermissionPrompt: true` を追加し、autoモードの確認ダイアログをスキップするよう設定

## Test plan
- [ ] Claude Code 起動時に autoモードの確認ダイアログが表示されないことを確認