### PR TITLE
chore: 古くなった設定の更新とBrewfileエントリの修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,3 @@
-# Amazon Q pre block. Keep at the top of this file.
-[[ -f "${HOME}/Library/Application Support/amazon-q/shell/zshrc.pre.zsh" ]] && builtin source "${HOME}/Library/Application Support/amazon-q/shell/zshrc.pre.zsh"
 # alias
 alias ls="ls -GF"
 alias ll="ls -la"
@@ -94,7 +92,7 @@ zle -N peco-history-selection
 bindkey '^R' peco-history-selection
 
 # gcloud
-GCLOUD_SDK_PATH="/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk"
+GCLOUD_SDK_PATH="/opt/homebrew/Caskroom/gcloud-cli/latest/google-cloud-sdk"
 [[ -f "$GCLOUD_SDK_PATH/path.zsh.inc" ]] && source "$GCLOUD_SDK_PATH/path.zsh.inc"
 ## easy to change gcloud project
 gcp-config() {
@@ -165,8 +163,5 @@ compdef _gcloud_complete gcloud
 ## azure
 AZ_COMPLETION="$(brew --prefix 2>/dev/null)/etc/bash_completion.d/az"
 [[ -f "$AZ_COMPLETION" ]] && source "$AZ_COMPLETION"
-
-# Amazon Q post block. Keep at the bottom of this file.
-[[ -f "${HOME}/Library/Application Support/amazon-q/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/amazon-q/shell/zshrc.post.zsh"
 
 [[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --locate-shell-integration-path zsh)"

--- a/Brewfile
+++ b/Brewfile
@@ -32,16 +32,10 @@ brew "pgcli"
 brew "pinact"
 brew "duckdb"
 brew "tflint"
-brew "amazon-q"
 brew "packer"
 brew "graphviz"
 brew "azure-cli"
 brew "terminal-notifier"
-
-# font
-brew "font-hackgen"
-brew "font-hackgen-nerd"
-brew "font-hack-nerd-font"
 
 # tap
 tap "homebrew/cask-fonts" # font
@@ -59,7 +53,6 @@ cask "raspberry-pi-imager"
 cask "bettertouchtool"
 cask "stats"
 cask "cyberduck"
-cask "google-cloud-sdk"
 cask "gcloud-cli"
 cask "keepassx"
 cask "visual-studio-code"
@@ -67,8 +60,12 @@ cask "slack"
 cask "figma"
 cask "drawio"
 cask "chatgpt"
-cask "kindle"
 cask "atok"
 cask "claude"
 cask "claude-code"
 cask "pgadmin4"
+
+# font
+cask "font-hackgen"
+cask "font-hackgen-nerd"
+cask "font-hack-nerd-font"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -94,6 +94,15 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r 'if (.tool_input.command // \"\" | test(\"gh pr create\")) then (.tool_response.stdout // \"\" | match(\"https://github\\\\.com/\\\\S+\") | .string) // empty else empty end' | { read -r url; [ -n \"$url\" ] && echo \"{\\\"systemMessage\\\": \\\"PR が作成されました: $url\\\"}\"; } 2>/dev/null || true"
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {


### PR DESCRIPTION
## 概要

dotfilesの各設定ファイルで古くなったエントリを更新し、誤った記述を修正します。

## 変更内容

### Brewfile
- `brew "amazon-q"` を削除（HomebrewからFormula/Caskが削除済み。Amazon Q → Kiro にリブランド）
- `cask "google-cloud-sdk"` を削除（`gcloud-cli` との重複。`google-cloud-sdk` は旧名）
- `cask "kindle"` を削除（Homebrewから削除済み）
- `brew "font-hackgen"`, `brew "font-hackgen-nerd"`, `brew "font-hack-nerd-font"` を `cask` セクションへ移動（これらはFormulaではなくCask）

### .zshrc
- Amazon Q のpre/postブロックを削除（Amazon Q未インストールのためシェル統合ファイルが存在しない）
- `GCLOUD_SDK_PATH` を `google-cloud-sdk` から `gcloud-cli` のパスに更新

### claude/settings.json
- ローカルのみで保持していたPR URL通知hook（PostToolUse/Bash）をコミット

## テスト計画

- [ ] Brewfileに不正なエントリが残っていないことを確認
- [ ] `.zshrc` のシェル読み込みが正常に動作することを確認
- [ ] `GCLOUD_SDK_PATH` が正しく解決されることを確認（`/opt/homebrew/Caskroom/gcloud-cli/latest/google-cloud-sdk` が存在する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)