### PR TITLE
fix: golangci-lint v2 の --out-format 廃止に対応

### DIFF
--- a/claude/hooks/lint-feedback.sh
+++ b/claude/hooks/lint-feedback.sh
@@ -40,7 +40,7 @@ case "$FILE" in
     ;;
   *.go)
     if command -v golangci-lint &>/dev/null; then
-      DIAG=$(golangci-lint run --out-format=line-number "$FILE" 2>&1 | head -30) || true
+      DIAG=$(golangci-lint run "$FILE" 2>&1 | head -30) || true
     fi
     ;;
   *.rs)


### PR DESCRIPTION
## 概要

golangci-lint v2 で `--out-format` フラグが廃止されたため、`lint-feedback.sh` の Go 向け lint コマンドから該当フラグを削除。

## 変更内容

- `golangci-lint run --out-format=line-number "$FILE"` → `golangci-lint run "$FILE"`

デフォルト出力にもファイル名・行番号・エラー内容が含まれるため、フィードバックの品質に影響なし。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)