### PR TITLE
fix: verify-tests hookのtimeoutコマンドをmacOSで動作するよう修正

### DIFF
--- a/claude/hooks/verify-tests.sh
+++ b/claude/hooks/verify-tests.sh
@@ -56,8 +56,15 @@ fi
 # No recognized test runner - pass through
 [ -z "$TEST_CMD" ] && exit 0
 
-# Run tests with 90s timeout
-OUTPUT=$(timeout 90 bash -c "$TEST_CMD" 2>&1 | tail -30)
+# Run tests with 90s timeout (use gtimeout on macOS if available, else run without timeout)
+if command -v timeout &>/dev/null; then
+  TIMEOUT_CMD="timeout 90"
+elif command -v gtimeout &>/dev/null; then
+  TIMEOUT_CMD="gtimeout 90"
+else
+  TIMEOUT_CMD=""
+fi
+OUTPUT=$($TIMEOUT_CMD bash -c "$TEST_CMD" 2>&1 | tail -30)
 EXIT_CODE=$?
 
 [ "$EXIT_CODE" -eq 0 ] && exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -146,8 +146,8 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/verify-tests.sh",
-            "statusMessage": "Verifying tests...",
-            "timeout": 100
+            "timeout": 100,
+            "statusMessage": "Verifying tests..."
           },
           {
             "type": "command",


### PR DESCRIPTION
## 概要

`verify-tests.sh` hookで使用している `timeout` コマンドがmacOSに存在せず、「timeout: command not found」エラーが発生していた問題を修正。

## 変更内容

- `timeout` → `gtimeout` → タイムアウトなし の順でフォールバックするよう変更
  - `timeout`: Linux / GNU coreutils
  - `gtimeout`: macOS + Homebrew coreutils
  - タイムアウトなし: どちらもない場合（Goなど個別フラグで制御済み）

## 動作確認

- macOS環境で `timeout: command not found` エラーが解消されることを確認