### PR TITLE
chore: デフォルトモデルのOpus固定を解除

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -63,7 +63,8 @@
       "WebFetch(domain:datatracker.ietf.org)",
       "WebFetch(domain:tools.ietf.org)",
       "WebFetch(domain:www.iana.org)",
-      "WebFetch(domain:www.icann.org)"
+      "WebFetch(domain:www.icann.org)",
+      "WebFetch(domain:googlecloudplatform.github.io)"
     ],
     "deny": [
       "Bash(sudo:*)",
@@ -107,7 +108,6 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "opus",
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "serena",
@@ -214,11 +214,11 @@
       }
     }
   },
+  "effortLevel": "high",
   "skipAutoPermissionPrompt": true,
   "toolSettings": {
     "bash": {
       "timeout": 300000
     }
-  },
-  "effortLevel": "high"
+  }
 }


### PR DESCRIPTION
## 概要

- `claude/settings.json` から `"model": "opus"` を削除し、Claude Code のデフォルトモデル選択ロジックに委ねるよう変更
- 合わせて `WebFetch` の許可ドメインに `googlecloudplatform.github.io` を追加
- `effortLevel` の記述位置を移動（機能的変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)