### PR TITLE
chore: Claude Code 設定を2.x系の新機能と整合させるブラッシュアップ

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,6 +1,10 @@
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "BASH_DEFAULT_TIMEOUT_MS": "300000"
+  },
+  "attribution": {
+    "commit": ""
   },
   "permissions": {
     "allow": [
@@ -40,7 +44,6 @@
       "Bash(rm .tmp/**)",
       "Bash(ls:*)",
       "Bash(osascript -e:*)",
-      "mcp__github__*",
       "mcp__chrome-devtools__*",
       "mcp__serena__*",
       "mcp__context7__*",
@@ -108,10 +111,8 @@
     ],
     "defaultMode": "auto"
   },
-  "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "serena",
-    "github",
     "chrome-devtools",
     "context7",
     "playwright"
@@ -214,11 +215,12 @@
       }
     }
   },
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "skipAutoPermissionPrompt": true,
-  "toolSettings": {
-    "bash": {
-      "timeout": 300000
-    }
+  "tui": "fullscreen",
+  "autoUpdatesChannel": "stable",
+  "showThinkingSummaries": true,
+  "worktree": {
+    "symlinkDirectories": ["node_modules", ".cache"]
   }
 }


### PR DESCRIPTION
## 概要

Claude Code v2.x系の更新をキャッチアップし、`claude/settings.json` をブラッシュアップしました。バグ/古い記述の修正、セキュリティ強化、2.x新機能の採用を1本にまとめています。

## 変更内容

### A. バグ/古い記述の修正

- **`toolSettings.bash.timeout`（スキーマに存在しない無効キー）を削除**し、公式env `BASH_DEFAULT_TIMEOUT_MS=300000` に移行
- **GitHub MCP 関連の削除**（`mcp__github__*` permission と `enabledMcpjsonServers` の `"github"`）
  - CLAUDE.md の「GitHub操作は `gh` コマンドを使用、MCPサーバーは使用しない」ポリシーと整合
- **`enableAllProjectMcpServers: true` を削除**
  - この boolean が true だと `enabledMcpjsonServers` のallowlistを上書きして全MCP自動承認になるため、明示的allowlist運用に統一

### B. Claude Code 2.x 新機能の採用

- `tui: "fullscreen"` — ちらつきのない alt-screen レンダラ、仮想スクロールバック
- `autoUpdatesChannel: "stable"` — stable channel へ固定、回帰リスク低減
- `showThinkingSummaries: true` — Ctrl+O で思考サマリを確認可能
- `attribution.commit: ""` — 不要な `Co-Authored-By: Claude` トレーラを非表示
- `worktree.symlinkDirectories: ["node_modules", ".cache"]` — `EnterWorktree` 使用時のディスク肥大化を防止

### C. その他

- `effortLevel` を `high` → `xhigh`（Extra High / Teamプラン機能）

## セキュリティ考慮事項

`enabledMcpjsonServers` の4サーバ（`serena`, `chrome-devtools`, `context7`, `playwright`）は **名前ベース信頼**で動いている点は継続課題として認識。悪意のあるリポジトリが同名の別MCPサーバを `.mcp.json` に仕込んだ場合、自動承認されるリスクが残ります。public dotfiles のグローバル設定として配布しているため、このリスクを認識した上で利便性とのバランスで現状のリストを維持。将来的に空配列にしてプロジェクトごとに都度承認する方式への切替も検討余地あり。

## レビュープロセス

`superpowers:requesting-code-review` による独立レビュー済み。
- Critical指摘（`effortLevel: "xhigh"` が enum外）はTeamプラン機能で公式スキーマにも記載があるため却下
- Important指摘（name-squattingリスク）は上記「セキュリティ考慮事項」として明記
- JSON構文、各新規キーのバイナリ内存在確認を全て完了

## 動作確認

- [x] `jq . settings.json` でJSON構文OK
- [x] 各新規キー/値を `strings /opt/homebrew/bin/claude | grep` でv2.1.104バイナリに存在確認
- [ ] シンボリックリンク再読み込み後、実機で警告が出ないこと（マージ後セッション再起動で確認）