### PR TITLE
fix: SSH接続時のTERM互換性問題を修正（tmux-256color → xterm-256color）

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -58,7 +58,7 @@ set-option -g status-left "#[fg=colour108,bg=colour237,bold] [#H #S:#I:#P] "
 # set-option -g status-right '#(wifi) #(battery --tmux) [%Y-%m-%d(%a) %H:%M]'
 
 # vim colorschema（True Color対応）
-set-option -g default-terminal "tmux-256color"
+set-option -g default-terminal "xterm-256color"
 set-option -sa terminal-overrides ",xterm-256color:RGB"
 
 # change color of active pane and deactive pane


### PR DESCRIPTION
## 概要

- tmux の `default-terminal` を `tmux-256color` から `xterm-256color` に変更

## 背景・原因

tmux 内では `TERM=tmux-256color` が設定されるが、多くのリモートサーバーには `tmux-256color` の terminfo がインストールされていない。
そのため SSH 接続後に vim・less・tput などが正常動作しない問題が発生していた。

## 対応

`.tmux.conf` の `default-terminal` を `xterm-256color` に変更。
True Color (RGB) サポートは既存の `terminal-overrides` 設定で引き続き維持される。

## テスト計画

- [ ] tmux を再起動後、`echo $TERM` が `xterm-256color` になることを確認
- [ ] SSH 接続先で vim・less が正常動作することを確認
- [ ] tmux 内でカラー表示が正常なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)