### PR TITLE
chore: Claude Code設定のブラッシュアップ

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -67,7 +67,9 @@
       "WebFetch(domain:tools.ietf.org)",
       "WebFetch(domain:www.iana.org)",
       "WebFetch(domain:www.icann.org)",
-      "WebFetch(domain:googlecloudplatform.github.io)"
+      "WebFetch(domain:googlecloudplatform.github.io)",
+      "WebFetch(domain:qiita.com)",
+      "WebFetch(domain:docs.anthropic.com)"
     ],
     "deny": [
       "Bash(sudo:*)",
@@ -194,6 +196,12 @@
       }
     ]
   },
+  "worktree": {
+    "symlinkDirectories": [
+      "node_modules",
+      ".cache"
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh",
@@ -216,11 +224,11 @@
     }
   },
   "effortLevel": "xhigh",
-  "skipAutoPermissionPrompt": true,
-  "tui": "fullscreen",
   "autoUpdatesChannel": "stable",
+  "tui": "fullscreen",
   "showThinkingSummaries": true,
-  "worktree": {
-    "symlinkDirectories": ["node_modules", ".cache"]
-  }
+  "language": "japanese",
+  "showClearContextOnPlanAccept": true,
+  "agentPushNotifEnabled": true,
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## 概要

Qiita記事と公式ドキュメントを参考に、Claude Codeのユーザー設定（`claude/settings.json`）をブラッシュアップした。

## 変更内容

### 追加
- `language: "japanese"` — Claudeの応答言語を設定レベルで明示的に日本語固定（`CLAUDE.md` の指示と整合）
- `showClearContextOnPlanAccept: true` — プラン受け入れ後にコンテキストクリアの選択肢を表示（長いセッションでの品質維持）
- `agentPushNotifEnabled: true` — エージェント完了時のプッシュ通知を有効化
- `WebFetch(domain:qiita.com)` / `WebFetch(domain:docs.anthropic.com)` — 参考記事・公式ドキュメントへのアクセスを許可

### 整理
- `worktree` ブロックを `hooks` 直後に移動（論理的なグルーピングのため、機能への影響なし）

## 参考資料
- [Qiita: Claude Codeの設定](https://qiita.com/ot12/items/06420caf41a34a910c53)
- [公式ドキュメント: settings](https://code.claude.com/docs/en/settings)

## 備考
- `agentPushNotifEnabled` と `Stop` フックの `terminal-notifier` が二重通知になる可能性があるが、前者はエージェントモード完了時、後者はセッション停止時と発火タイミングが異なるため実用上は問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)