### PR TITLE
chore: Brewfileからdocker-desktopを除外

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -42,7 +42,6 @@ tap "joachimbrindeau/ccusage-monitor" # claude code usage menu bar
 
 # cask
 cask "alfred"
-cask "docker-desktop"
 cask "iina"
 cask "notion"
 cask "appcleaner"


### PR DESCRIPTION
## Summary

- Brewfile から `cask "docker-desktop"` を削除
- 今後 Docker Desktop は公式インストーラで管理する

## 背景

Docker Desktop はアプリ内蔵のオートアップデーター機構を持っており、Homebrew Cask 経由で管理すると両者が競合してアプリ内アップデートが失敗する事象が発生していた。Cask 管理から外すことで Docker Desktop 自身のアップデート機構に一元化する。

なお、`claude/mcp-setup.sh` で `docker run` を使用するため Docker Desktop 自体は引き続き必要。公式インストーラ ( https://www.docker.com/products/docker-desktop/ ) で導入する。

## ローカル側の対応

PR とは別に、各環境で以下のいずれかを実施する想定:

- 設定残し: `brew uninstall --cask docker-desktop`
- 完全削除: `brew uninstall --cask --zap docker-desktop` してから公式インストーラで再インストール

## Test plan

- [x] `git diff` で Brewfile の該当行のみが削除されていることを確認
- [x] 他スクリプト (`install.sh` 等) が `docker-desktop` cask の存在を前提にしていないことを確認
- [x] コードレビューエージェントによる承認取得