### PR TITLE
chore: statusline のトークン計算修正と ccusage-monitor 撤去

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -33,12 +33,10 @@ brew "graphviz"
 brew "azure-cli"
 brew "terminal-notifier"
 brew "cloudflare-wrangler"
-brew "joachimbrindeau/ccusage-monitor/ccusage-monitor"
 
 # tap
 tap "homebrew/cask-fonts" # font
 tap "hashicorp/tap" # hashicorp
-tap "joachimbrindeau/ccusage-monitor" # claude code usage menu bar
 
 # cask
 cask "alfred"

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -23,8 +23,9 @@ CONTEXT_SIZE=$(echo "$INPUT" | jq -r '.context_window.context_window_size // 200
 USAGE=$(echo "$INPUT" | jq '.context_window.current_usage')
 
 if [ "$USAGE" != "null" ] && [ -n "$USAGE" ]; then
-    # 現在のコンテキスト使用量を計算
-    USED=$(echo "$USAGE" | jq '.input_tokens + .output_tokens + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0)')
+    # コンテキストの input トークン合計 = 新規 input + キャッシュ作成 + キャッシュ読み込み
+    # output_tokens は次ターンで input 側に回るが、現時点の context input 占有量には含めない
+    USED=$(echo "$USAGE" | jq '.input_tokens + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0)')
 else
     USED=0
 fi


### PR DESCRIPTION
## Summary

- `claude/statusline.sh` のコンテキスト使用量計算から `output_tokens` を除外。Claude Code の statusline JSON 契約に従い、context input 占有量 = `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` に揃えました。これまでは `output_tokens` も足しており、ターン直後の表示がわずかに過大になっていました。
- `Brewfile` から `joachimbrindeau/ccusage-monitor` (formula + tap) を削除。`/usage` 相当の値をメニューバーに出す目的で入れていましたが、ローカル jsonl 集計はサーバ側レート制限カウンタとどうしてもズレるため、撤去しました。アンインストール・untap・LaunchAgent plist 削除はローカルで実施済み。

## なぜこの変更か

`/usage` の値をメニューバーで再現するクリーンな手段は現状ありません（Anthropic 個人向け Usage API 未公開、`claude` CLI にもサブコマンドなし）。実用解は「statusline でコンテキスト％だけ正しく出す」+「レート上限は必要時に `/usage` を手で叩く」の組み合わせです。

## Test plan

- [x] `statusline.sh` をサンプル JSON で実行し、`output_tokens` が合計に含まれないことを確認
- [x] shellcheck パス
- [x] `brew uninstall ccusage-monitor` / `brew untap joachimbrindeau/ccusage-monitor` 実行済み
- [x] `~/Library/LaunchAgents/com.ccusage.monitor.plist` 削除済み
- [x] 独立コードレビュー（superpowers:requesting-code-review）通過

## Notes

ローカル限定の `.claude/settings.local.json` から ccusage 関連の WebFetch 許可も併せて削除しました（git 非追跡のため PR diff には含まれません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)