### PR TITLE
feat: /usage を即叩けるホットキー用スクリプト追加

### DIFF
--- a/claude/check-usage.sh
+++ b/claude/check-usage.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Focus iTerm and type `/usage` into the front Claude Code session.
+# Bind this script to a global hotkey via Shortcuts.app or BetterTouchTool.
+# Assumes the focused iTerm session is already running `claude` (CLI).
+# Requires Accessibility permission for the invoking app (BTT / Shortcuts.app).
+
+set -euo pipefail
+
+osascript <<'APPLESCRIPT'
+tell application "System Events"
+    if not (exists process "iTerm2") then
+        error "iTerm is not running" number -128
+    end if
+end tell
+
+tell application "iTerm" to activate
+
+-- Wait until iTerm is actually frontmost before sending keystrokes,
+-- otherwise the first chars can be eaten by the previously focused app.
+repeat 20 times
+    tell application "System Events"
+        if frontmost of process "iTerm2" then exit repeat
+    end tell
+    delay 0.05
+end repeat
+
+tell application "System Events"
+    keystroke "/usage"
+    key code 36
+end tell
+APPLESCRIPT


### PR DESCRIPTION
## Summary

- `claude/check-usage.sh` を追加。グローバルホットキー（Shortcuts.app / BetterTouchTool）から呼び出すと iTerm をフォーカスして `/usage<Enter>` を送り込みます。
- `/usage` の値をメニューバーに連続表示するクリーンな手段が現状存在しない（ローカルログ集計はサーバ側カウンタとズレる、公式 Usage API 未公開）ための代替。1キーで `/usage` を呼び出せるようにする最小限のヘルパー。

## 実装メモ

レビュー指摘を踏まえて以下を盛り込み済み:
- iTerm が未起動なら `osascript` がエラーで終了（`set -e` で伝播）。誤って起動 + shell に `/usage` 投下を防止
- `tell ... to activate` の直後ではなく、iTerm が実際に frontmost になるまで最大1秒ポーリング。先行キーストロークの取りこぼし防止
- Accessibility 権限が必要な旨をスクリプト冒頭にコメント
- exec ビット (100755) を git update-index で付与

## 使い方（コミットには含めない、メモのみ）

macOS Shortcuts.app の場合:
1. 新規ショートカット作成 → "Run Shell Script" アクション
2. Shell: `/bin/bash`、Pass input: `to stdin`、Script: `~/path/to/dotfiles/claude/check-usage.sh`
3. ショートカット詳細でキーボードショートカットを割り当て（例: ⌥⌘U）
4. 初回実行時に Shortcuts.app の Accessibility 権限を許可

BetterTouchTool の場合: Keyboard → Add New Shortcut → Run Real Shell Script で同様。

## Test plan

- [x] shellcheck パス
- [x] `osascript` 構文確認（iTerm2 プロセス検出が動くことを確認）
- [x] 独立コードレビュー (superpowers:requesting-code-review) を Important 3点を反映後に再確認: With fixes 指摘の全項目に対応
- [ ] ホットキー割当後、別アプリにフォーカスがある状態から hotkey → iTerm 前面化 + `/usage` 投下が成功すること（ユーザー側で実機確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)