### PR TITLE
fix: settings.jsonの末尾カンマを修正

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -52,7 +52,7 @@
       "WebSearch",
       "WebFetch",
       "Skill(superpowers:requesting-code-review)",
-      "Skill(superpowers:requesting-code-review:*)",
+      "Skill(superpowers:requesting-code-review:*)"
     ],
     "deny": [
       "Bash(sudo:*)",


### PR DESCRIPTION
## 概要

`claude/settings.json` の `permissions.allow` 配列末尾に余分なカンマがあり、JSONとして不正な状態になっていたため修正します。

## 変更内容

- 55行目 `Skill(superpowers:requesting-code-review:*)` の末尾の trailing comma を削除

## 影響

JSON は trailing comma を許可しないため、Claude Code が settings.json をパースできず "invalid or malformed json" エラーが出ていました。本修正により正常にロードされるようになります。

## 動作確認

```
$ python3 -m json.tool claude/settings.json > /dev/null && echo "Valid JSON"
Valid JSON
```