### PR TITLE
chore: ハードコードされた /Users/stkhr パスを ${HOME} に置換

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -95,7 +95,7 @@ gcp-config() {
 # asdf
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 ## nom install
-## ln -s .asdf/shims/claude "$HOME"/.asdf/installs/nodejs/24.1.0/bin/claude
+## ln -s .asdf/shims/claude "$HOME/.asdf/installs/nodejs/24.1.0/bin/claude"
 
 # kubectl
 if command -v kubectl >/dev/null 2>&1; then

--- a/.zshrc
+++ b/.zshrc
@@ -95,7 +95,7 @@ gcp-config() {
 # asdf
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 ## nom install
-## ln -s .asdf/shims/claude /Users/stkhr/.asdf/installs/nodejs/24.1.0/bin/claude
+## ln -s .asdf/shims/claude "$HOME"/.asdf/installs/nodejs/24.1.0/bin/claude
 
 # kubectl
 if command -v kubectl >/dev/null 2>&1; then

--- a/claude/README.md
+++ b/claude/README.md
@@ -252,7 +252,7 @@ export GITHUB_PERSONAL_ACCESS_TOKEN="ghp_xxxxxxxxxxxxx"
     "command": "docker",
     "args": [
       "run", "--rm", "-i", "--network", "host",
-      "-v", "/Users/stkhr:/workspaces/projects",
+      "-v", "$HOME:/workspaces/projects",
       "ghcr.io/oraios/serena:latest",
       "serena", "start-mcp-server",
       "--transport", "stdio",
@@ -285,7 +285,7 @@ export GITHUB_PERSONAL_ACCESS_TOKEN="ghp_xxxxxxxxxxxxx"
 
 **注意点**:
 - `~/.claude.json`のトップレベルの`mcpServers`に追加（`projects`の外）
-- Serenaの`/Users/stkhr`パスは環境に応じて変更してください
+- Serenaの`$HOME`パスは環境に応じて変更してください
 - JSONの構文エラーに注意（カンマの位置など）
 
 #### 3. 設定の確認

--- a/claude/README.md
+++ b/claude/README.md
@@ -252,7 +252,7 @@ export GITHUB_PERSONAL_ACCESS_TOKEN="ghp_xxxxxxxxxxxxx"
     "command": "docker",
     "args": [
       "run", "--rm", "-i", "--network", "host",
-      "-v", "$HOME:/workspaces/projects",
+      "-v", "${HOME}:/workspaces/projects",
       "ghcr.io/oraios/serena:latest",
       "serena", "start-mcp-server",
       "--transport", "stdio",
@@ -285,7 +285,8 @@ export GITHUB_PERSONAL_ACCESS_TOKEN="ghp_xxxxxxxxxxxxx"
 
 **注意点**:
 - `~/.claude.json`のトップレベルの`mcpServers`に追加（`projects`の外）
-- Serenaの`$HOME`パスは環境に応じて変更してください
+- Serenaのマウント元パス（例: `${HOME}` を `${HOME}/src` 等に変更）は環境に応じて調整してください
+- Claude Code のMCP設定では `${VAR}` 形式の環境変数展開がサポートされています
 - JSONの構文エラーに注意（カンマの位置など）
 
 #### 3. 設定の確認


### PR DESCRIPTION
## Summary

- セキュリティ・portability レビューの一環として、リポジトリ内にハードコードされていた `/Users/stkhr` 絶対パスを `${HOME}` / `$HOME` に置換
- 対象は `.zshrc` のコメント1箇所と `claude/README.md` の Serena MCP セットアップ例
- 他のユーザー(または stkhr 本人の新環境)が clone してそのまま利用できるよう改善

## Changes

- [.zshrc:98](../blob/chore/replace-hardcoded-user-paths/.zshrc#L98): コメント例を `"$HOME/.asdf/..."` 形式に統一
- [claude/README.md:255](../blob/chore/replace-hardcoded-user-paths/claude/README.md#L255): Docker `-v` 引数を `${HOME}:/workspaces/projects` に変更(Claude Code MCP は `${VAR}` 形式のみ展開対応のため波括弧付き)
- [claude/README.md:288](../blob/chore/replace-hardcoded-user-paths/claude/README.md#L288): 注意書きを `${VAR}` 展開仕様に合わせて更新

## Review

`superpowers:requesting-code-review` を 2 回実施し、Critical 指摘(bare `$HOME` は MCP では展開されない)を反映してから再レビューで Ready to merge を取得済み。

## Test plan

- [x] `git grep -nE "/Users/[a-zA-Z]+"` でトラッキングファイルにヒット 0 件を確認
- [x] `.zshrc` の変更はコメント行のため動作影響なし
- [ ] (任意)新環境で `install.sh` 実行 → `claude mcp list` で serena が起動することの確認