### PR TITLE
chore(claude): プロジェクト共有 settings.json で頻出 read-only ツールを許可リスト化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__claude_ai_Slack__slack_search_public_and_private",
+      "mcp__claude_ai_Slack__slack_read_thread",
+      "mcp__claude_ai_Atlassian_Rovo__searchJiraIssuesUsingJql",
+      "Bash(uv run ruff *)",
+      "Bash(uv run pyright *)",
+      "Bash(shellcheck *)",
+      "Bash(actionlint *)",
+      "Bash(tflint *)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "mcp__claude_ai_Slack__slack_search_public_and_private",
       "mcp__claude_ai_Slack__slack_read_thread",
       "mcp__claude_ai_Atlassian_Rovo__searchJiraIssuesUsingJql",
-      "Bash(uv run ruff *)",
+      "Bash(uv run ruff check *)",
       "Bash(uv run pyright *)",
       "Bash(shellcheck *)",
       "Bash(actionlint *)",


### PR DESCRIPTION
## 概要

`/fewer-permission-prompts` の結果に基づき、プロジェクト共有の `.claude/settings.json` を新規作成し、頻繁に使う read-only ツールを許可リストに追加します。直近50セッションのトランスクリプトから3件以上呼ばれているもののうち、以下に該当しないものを抽出しました:

- Claude Code がデフォルトで auto-allow しているもの (`head`, `tail`, `grep`, `ls`, `cd`, `pwd`, `cat`, `wc`, `find`, `git` 系/`gh` 系の read-only サブコマンド等)
- グローバル `~/.claude/settings.json` の広いワイルドカード (`Bash(git:*)`, `Bash(gh:*)`, `Bash(terraform:*)`, `Bash(docker:*)`, `Bash(python3:*)`, `mcp__context7__*` 等) でカバー済みのもの
- ローカル `.claude/settings.local.json` で既に許可されているもの

## 変更内容

| パターン | 件数 | 用途 |
|---|---|---|
| `mcp__claude_ai_Slack__slack_search_public_and_private` | 21 | Slack 検索 |
| `mcp__claude_ai_Atlassian_Rovo__searchJiraIssuesUsingJql` | 7 | Jira JQL 検索 |
| `Bash(uv run ruff check *)` | 7 | Python lint (read-only check のみ) |
| `Bash(shellcheck *)` | 5 | シェル lint |
| `Bash(actionlint *)` | 4 | GitHub Actions lint |
| `Bash(uv run pyright *)` | 4 | Python 型チェック |
| `mcp__claude_ai_Slack__slack_read_thread` | 3 | Slack スレッド読み取り |
| `Bash(tflint *)` | 3 | Terraform lint |

## 設計上のメモ

- `uv run` は本来ワイルドカード許可禁止（任意コード実行になりうるため）だが、`ruff check` / `pyright` のように特定の lint/型チェック実行ファイルに限定する形なら、任意コード実行リスクは閉じる。
- `ruff format` や `ruff check --fix` はファイルを書き換えるため、ruff は `check` サブコマンドに限定した（コードレビュー指摘を反映）。
- `tflint` は `tflint --init` でプラグインの DL を行うが、lint 運用上必要かつネットワーク I/O のみで任意コード実行ではないため許容。
- 公開リポジトリだが、Slack / Jira の MCP 名は claude.ai 内蔵 MCP の汎用名で、ワークスペース ID 等の機密情報は含まれない。

## レビュー

- `superpowers:requesting-code-review` で独立エージェントレビュー実施済み。
- Critical 指摘: なし
- Important 指摘 (2件): ruff/tflint の副作用 → ruff は `check` 限定に修正、tflint は意図的に許容と明記

## テスト計画

- [ ] PR マージ後、`.claude/settings.json` の追加パターンがプロンプトなしで実行されることを次回セッションで確認