### PR TITLE
feat(tmux): pane3 を上下に分割して pane4 を追加

### DIFF
--- a/.tmux.session.conf
+++ b/.tmux.session.conf
@@ -7,10 +7,12 @@
 #   |          pane 1             |
 #   |          (main)             |
 #   +--------------+--------------+
-#   |    pane 2    |    pane 3    |
+#   |              |    pane 3    |
+#   |    pane 2    +--------------+
+#   |              |    pane 4    |
 #   +--------------+--------------+
 #
-# Strategy: create all panes first, then apply layout in one shot.
+# Strategy: create initial panes first, then apply layout in one shot.
 # Avoids the prompt-redraw race where resize-pane fires before pane 2's
 # zsh+sheldon finish initializing, which leaves the bottom-left pane
 # without a visible prompt.
@@ -23,6 +25,11 @@ splitw -h -d -t 2 -c "#{pane_current_path}"
 # Apply layout in a single step so resize events don't race with shell init.
 set-window-option main-pane-height 60%
 select-layout main-horizontal
+
+# Split pane 3 vertically to create pane 4 below it. Done after the main
+# layout so the bottom-left (pane 2) is no longer touched and avoids the
+# resize/shell-init race for that pane.
+splitw -v -d -t 3 -c "#{pane_current_path}"
 
 # Focus pane 1.
 select-pane -t 1


### PR DESCRIPTION
## 概要

tmux 起動時のレイアウトを変更し、右下の pane 3 を上下に分割して pane 4 を追加。

### Before
```
+-----------------------------+
|          pane 1             |
+--------------+--------------+
|    pane 2    |    pane 3    |
+--------------+--------------+
```

### After
```
+-----------------------------+
|          pane 1             |
+--------------+--------------+
|              |    pane 3    |
|    pane 2    +--------------+
|              |    pane 4    |
+--------------+--------------+
```

## 変更点

- `select-layout main-horizontal` の後に `splitw -v -d -t 3` を追加し、pane 3 を上下分割。
- ヘッダの ASCII アートとコメントを新レイアウトに合わせて更新。

## レース修正の温存について

[4fcc567](https://github.com/stkhr/dotfiles/commit/4fcc567) で対処した「pane 2 (左下) のプロンプト再描画レース」を再発させないため、追加 split は `select-layout` 完了後に実行し、対象を pane 3 のみに限定している。pane 2 には新たな resize イベントが当たらない。

## 検証

隔離ソケットで起動して 4 ペインのジオメトリを確認済み:

```bash
tmux -L _test -f ~/.tmux.conf new-session -d -s test -x 200 -y 50 \
  \; source-file ~/.tmux.session.conf \
  \; list-panes -F '#{pane_index} x=#{pane_left} y=#{pane_top} w=#{pane_width} h=#{pane_height}'
```

結果:
- pane 1: 200×29 (top, full width)
- pane 2: 100×20 (bottom-left)
- pane 3: 99×10 (bottom-right top)
- pane 4: 99×9  (bottom-right bottom)

## レビュー

`superpowers:requesting-code-review` を実施し承認済み (Critical/Important なし、Minor のみ・修正不要との判断)。