### PR TITLE
feat(claude): セッションログのObsidian同期フックを設定に追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -184,6 +184,10 @@
           {
             "type": "command",
             "command": "terminal-notifier -title \"Claude Code\" -message \"作業が完了しました\" -sound Glass"
+          },
+          {
+            "type": "command",
+            "command": "[ -f ~/.claude/hooks/session-sync.sh ] && bash ~/.claude/hooks/session-sync.sh || true"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -187,7 +187,7 @@
           },
           {
             "type": "command",
-            "command": "[ -f ~/.claude/hooks/session-sync.sh ] && bash ~/.claude/hooks/session-sync.sh || true"
+            "command": "if [ -x ~/.claude/hooks/session-sync.sh ]; then ~/.claude/hooks/session-sync.sh || true; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Stopフックに `session-sync.sh`(dotfiles外で管理されるセッションログ同期スクリプト)への呼び出しを追加
- `if-then-fi` + `[ -x ... ]` のガード付きで、スクリプトが存在・実行可能なマシンでのみ動作する

## 背景

セッションログをObsidian vaultへ同期するStopフックを `~/.claude/settings.local.json` に登録していたが、Claude Codeのスコープ仕様上 `~/.claude/settings.local.json` は読み込まれず、Stopフックが無効状態だった。

## 変更内容

`claude/settings.json` のStopフック配列に1エントリ追加:

```json
{
  "type": "command",
  "command": "if [ -x ~/.claude/hooks/session-sync.sh ]; then ~/.claude/hooks/session-sync.sh || true; fi"
}
```

設計上のポイント:

- **スクリプト本体はdotfiles外**: パーソナルなObsidian連携を含むためpublic dotfilesにはコミットしない。フックエントリだけリポジトリで管理。
- **存在/実行可能チェック**: スクリプトが無いマシンでも害なし。
- **`A && B || C` 罠の回避**: `if-then-fi` 形式で、スクリプト本体の終了コードに関わらず兄弟フックをブロックしない契約を明示。
- **`|| true`**: スクリプト内エラーがStop全体を止めないようにする保険。

## Test plan

- [x] `jq empty claude/settings.json` でJSON妥当性確認
- [x] コードレビューエージェントの承認(Important指摘2件を修正後の状態)
- [ ] マージ後、次セッションのStop時にvaultへログが追記されることを確認