### PR TITLE
fix(install): register claude-plugins-official marketplace before plugin install

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -35,7 +35,6 @@ brew "terminal-notifier"
 brew "cloudflare-wrangler"
 
 # tap
-tap "homebrew/cask-fonts" # font
 tap "hashicorp/tap" # hashicorp
 
 # cask

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -219,6 +219,12 @@
         "source": "github",
         "repo": "hashicorp/agent-skills"
       }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
     }
   },
   "language": "japanese",

--- a/install.sh
+++ b/install.sh
@@ -77,15 +77,20 @@ fi
 
 # claude plugins
 if command -v claude &> /dev/null; then
+    # Register marketplaces first (idempotent — safe to re-run)
+    claude plugin marketplace add anthropics/claude-plugins-official
+    claude plugin marketplace add hashicorp/agent-skills
+
+    # Anthropic official plugins
     claude plugin install superpowers@claude-plugins-official
-    # HashiCorp Terraform plugins
-    claude plugin marketplace add hashicorp/agent-skills 2>/dev/null || true
-    claude plugin install terraform-code-generation@hashicorp
-    claude plugin install terraform-module-generation@hashicorp
-    claude plugin install terraform-provider-development@hashicorp
     claude plugin install frontend-design@claude-plugins-official
     claude plugin install context7@claude-plugins-official
     claude plugin install security-guidance@claude-plugins-official
+
+    # HashiCorp Terraform plugins
+    claude plugin install terraform-code-generation@hashicorp
+    claude plugin install terraform-module-generation@hashicorp
+    claude plugin install terraform-provider-development@hashicorp
 fi
 
 # aws amazonq


### PR DESCRIPTION
## Summary
- 新規端末で `install.sh` 実行時に `claude-plugins-official` 系プラグイン（superpowers / frontend-design / context7 / security-guidance）がインストールされない問題を修正。marketplace を明示的に `add` してから plugin install する順序に変更
- 廃止された `homebrew/cask-fonts` tap を Brewfile から削除（フォント cask は homebrew/cask 本体に統合済み）
- 同 marketplace を `claude/settings.json` にも宣言追加し、宣言ベースでも管理（install.shの明示的add と二重化、いずれも冪等）