### PR TITLE
ルートREADME整備・tmuxモダン化・Claude hooksの切り出し（Phase 2）

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,7 +48,7 @@ set-option -g status-position top
 set-option -g status-left-length 90
 set-option -g status-right-length 90
 #set-option -g status-justify centre
-set-option -g status-interval 1
+set-option -g status-interval 5
 
 set-option -g status-left "#[fg=colour108,bg=colour237,bold] [#H #S:#I:#P] "
 
@@ -57,9 +57,12 @@ set-option -g status-left "#[fg=colour108,bg=colour237,bold] [#H #S:#I:#P] "
 ### https://github.com/b4b4r07/dotfiles/blob/master/.tmux/bin/battery
 # set-option -g status-right '#(wifi) #(battery --tmux) [%Y-%m-%d(%a) %H:%M]'
 
-# vim colorschema（True Color対応）
-set-option -g default-terminal "xterm-256color"
-set-option -sa terminal-overrides ",xterm-256color:RGB"
+# True Color対応（tmux-256color の terminfo は macOS 標準に同梱）
+set-option -g default-terminal "tmux-256color"
+set-option -as terminal-features ",xterm-256color:RGB"
+
+# 画像プロトコル等のエスケープシーケンスをパススルー
+set-option -g allow-passthrough on
 
 # change color of active pane and deactive pane
 set -g window-style 'fg=colour245,bg=colour236'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,40 @@
 # dotfiles
 
-## vscode
+macOS 向けの各種ツール設定を管理するリポジトリ。`install.sh` がホームディレクトリへ
+シンボリックリンクを配置する。
+
+## セットアップ
 
 ```bash
-# listup
+# Homebrew パッケージのインストール
+brew bundle
+
+# シンボリックリンクの配置 + Claude Code セットアップ
+zsh install.sh
+```
+
+install.sh は再実行可能（リンクは `ln -snf` で張り直されるため、リポジトリを
+移動した場合も再実行すれば追従する）。
+
+## 構成
+
+| パス | 配置先 | 内容 |
+|---|---|---|
+| `.zshrc` / `.tmux.conf` / `.tmux.session.conf` / `.vimrc` | `~/` | シェル・tmux・vim |
+| `config/starship.toml` | `~/.config/` | プロンプト（starship） |
+| `config/sheldon/plugins.toml` | `~/.config/sheldon/` | zsh プラグイン管理（sheldon） |
+| `claude/` | `~/.claude/` | Claude Code 設定一式（詳細は [claude/README.md](claude/README.md)） |
+| `vscode/` | （手動） | VSCode 設定・拡張リスト |
+| `Brewfile` | - | Homebrew パッケージ定義 |
+
+リポジトリ自体は ghq 管理（`~/ghq/github.com/stkhr/dotfiles`）。
+
+## VSCode
+
+```bash
+# 拡張リストの書き出し
 code --list-extensions > ./vscode/extensions
 
-# install
+# 拡張のインストール
 xargs -n 1 code --install-extension < ./vscode/extensions
 ```

--- a/claude/README.md
+++ b/claude/README.md
@@ -53,9 +53,7 @@ claude/
 | notion | Notion連携 | HTTP（`https://mcp.notion.com/mcp`） |
 | aws | AWS API操作（SigV4認証） | uvx `mcp-proxy-for-aws`（要 `brew install uv`） |
 
-- user スコープで登録したサーバーは登録した時点で有効になる。`settings.json` の
-  `enabledMcpjsonServers` はプロジェクトスコープ（`.mcp.json`）で定義された
-  サーバーの事前承認用であり、user スコープのサーバーには作用しない
+- user スコープで登録したサーバーは登録した時点で有効になる
 - バージョンを上げる場合は `mcp-setup.sh` のピン留めを更新し、
   `claude mcp remove <name>` してから再実行する（`claude mcp add` は同名サーバーが
   あるとエラーになる）
@@ -72,13 +70,14 @@ GitHub 操作は MCP ではなく `gh` CLI を使う方針のため、GitHub MCP
 |---|---|---|
 | `protect-main-branch.sh` | PreToolUse (Bash) | main/master への `git commit` をブロック |
 | `lint-feedback.sh` | PostToolUse (Edit\|Write) | 編集ファイルを lint し、エラーをモデルにフィードバック |
+| `format-on-edit.sh` | PostToolUse (Edit\|Write) | prettier / black / gofmt による自動整形 |
+| `notify-pr-created.sh` | PostToolUse (Bash) | `gh pr create` 実行時に PR URL を通知 |
 | `precompact-context.sh` | PreCompact | git の作業状態を compaction サマリに注入 |
 | `verify-tests.sh` | Stop | 応答完了時のテスト検証 |
 | `session-sync.sh` | Stop | セッション状態の同期 |
 
-このほか settings.json 内のインラインフックとして、PR作成URLの通知（PostToolUse）、
-コード整形（prettier / black / gofmt）、macOS通知（`osascript` による Notification /
-Stop 通知）を設定している。
+このほか settings.json 内のインラインフックとして、macOS通知（`osascript` による
+Notification / Stop 通知）を設定している。
 
 ## Skills / Agents
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -70,7 +70,7 @@ GitHub 操作は MCP ではなく `gh` CLI を使う方針のため、GitHub MCP
 |---|---|---|
 | `protect-main-branch.sh` | PreToolUse (Bash) | main/master への `git commit` をブロック |
 | `lint-feedback.sh` | PostToolUse (Edit\|Write) | 編集ファイルを lint し、エラーをモデルにフィードバック |
-| `format-on-edit.sh` | PostToolUse (Edit\|Write) | prettier / black / gofmt による自動整形 |
+| `format-on-edit.sh` | PostToolUse (Edit\|Write) | prettier / black / gofmt / terraform fmt による自動整形 |
 | `notify-pr-created.sh` | PostToolUse (Bash) | `gh pr create` 実行時に PR URL を通知 |
 | `precompact-context.sh` | PreCompact | git の作業状態を compaction サマリに注入 |
 | `verify-tests.sh` | Stop | 応答完了時のテスト検証 |

--- a/claude/hooks/format-on-edit.sh
+++ b/claude/hooks/format-on-edit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# PostToolUse (Edit|Write): 編集されたファイルを言語別フォーマッタで整形する。
+# フォーマッタ未導入・整形失敗は無視する（lint-feedback.sh が品質面を担当）。
+
+set -uo pipefail
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+[ -z "$FILE" ] || [ ! -f "$FILE" ] && exit 0
+
+case "$FILE" in
+  *.ts|*.tsx|*.js|*.jsx|*.json|*.md)
+    command -v prettier &>/dev/null && prettier --write "$FILE" 2>/dev/null
+    ;;
+  *.py)
+    command -v black &>/dev/null && black -q "$FILE" 2>/dev/null
+    ;;
+  *.go)
+    command -v gofmt &>/dev/null && gofmt -w "$FILE" 2>/dev/null
+    ;;
+esac
+
+exit 0

--- a/claude/hooks/format-on-edit.sh
+++ b/claude/hooks/format-on-edit.sh
@@ -19,6 +19,10 @@ case "$FILE" in
   *.go)
     command -v gofmt &>/dev/null && gofmt -w "$FILE" 2>/dev/null
     ;;
+  *.tf|*.tfvars)
+    # 変更ファイル単位で整形する（-recursive でスコープ外まで整形しない）
+    command -v terraform &>/dev/null && terraform fmt "$FILE" >/dev/null 2>&1
+    ;;
 esac
 
 exit 0

--- a/claude/hooks/notify-pr-created.sh
+++ b/claude/hooks/notify-pr-created.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# PostToolUse (Bash): gh pr create の出力から PR URL を拾い、systemMessage で通知する。
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+
+echo "$COMMAND" | grep -q 'gh pr create' || exit 0
+
+URL=$(echo "$INPUT" | jq -r '.tool_response.stdout // ""' 2>/dev/null \
+  | grep -oE 'https://github\.com/\S+' | head -1)
+
+if [ -n "$URL" ]; then
+  jq -n --arg msg "PR が作成されました: $URL" '{systemMessage: $msg}'
+fi
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -104,13 +104,6 @@
     ],
     "defaultMode": "auto"
   },
-  "enabledMcpjsonServers": [
-    "serena",
-    "chrome-devtools",
-    "context7",
-    "playwright",
-    "aws"
-  ],
   "hooks": {
     "PreToolUse": [
       {
@@ -129,7 +122,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r 'if (.tool_input.command // \"\" | test(\"gh pr create\")) then (.tool_response.stdout // \"\" | match(\"https://github\\\\.com/\\\\S+\") | .string) // empty else empty end' | { read -r url; [ -n \"$url\" ] && echo \"{\\\"systemMessage\\\": \\\"PR が作成されました: $url\\\"}\"; } 2>/dev/null || true"
+            "command": "~/.claude/hooks/notify-pr-created.sh"
           }
         ]
       },
@@ -138,7 +131,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // empty' 2>/dev/null); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ]; then case \"$FILE\" in *.ts|*.tsx|*.js|*.jsx|*.json|*.md) command -v prettier &>/dev/null && prettier --write \"$FILE\" 2>/dev/null ;; *.py) command -v black &>/dev/null && black -q \"$FILE\" 2>/dev/null ;; *.go) command -v gofmt &>/dev/null && gofmt -w \"$FILE\" 2>/dev/null ;; esac; fi"
+            "command": "~/.claude/hooks/format-on-edit.sh"
           },
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- ルートREADMEにセットアップ手順と構成表を整備
- .tmux.conf をモダン化（tmux-256color + terminal-features RGB / allow-passthrough / status-interval 1s→5s）
- settings.json のインラインhook 2件を `claude/hooks/` のスクリプトに切り出し（挙動は不変、shellcheck 検証済み）
- 全MCPサーバーが user スコープ登録のため作用しない `enabledMcpjsonServers` を settings.json から削除