### PR TITLE
chore(claude): settings.json を最新仕様に合わせて改善

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "BASH_DEFAULT_TIMEOUT_MS": "300000"
   },
   "attribution": {
-    "commit": ""
+    "commit": "",
+    "pr": ""
   },
   "permissions": {
     "allow": [
@@ -122,7 +124,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/notify-pr-created.sh"
+            "command": "~/.claude/hooks/notify-pr-created.sh",
+            "if": "Bash(gh pr create*)"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- settings.json に `$schema` を追加し、エディタ上でキーのtypoや非推奨化を検知できるようにする
- `attribution.pr` を空文字に設定し、PR本文へのClaude Code署名抑止をプロンプト指示から設定レベルの保証に変更
- `notify-pr-created` フックに `if` フィルタを追加し、`gh pr create` 実行時のみ起動するようにする（protect-main-branch は安全装置のため意図的に無フィルタを維持）