### PR TITLE
feat(ssh): SSH汎用設定をdotfilesのconf.dで管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .agents/
 .worktrees/
 docs/
+ssh/conf.d/private*.conf

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,22 @@ do
     ln -snfv "$DIR"/"$f" "$HOME"/"$f"
 done
 
+# ssh conf.d
+mkdir -p "$HOME"/.ssh/conf.d
+chmod 700 "$HOME"/.ssh/conf.d
+ln -snfv "$DIR"/ssh/conf.d/general.conf "$HOME"/.ssh/conf.d/general.conf
+chmod 600 "$HOME"/.ssh/conf.d/general.conf
+# ~/.ssh/config の先頭に Include がなければ追記
+if ! grep -q "Include conf.d/\*.conf" "$HOME/.ssh/config" 2>/dev/null; then
+    if [ -f "$HOME/.ssh/config" ]; then
+        printf "Include conf.d/*.conf\n\n" | cat - "$HOME/.ssh/config" > "$HOME/.ssh/config.tmp"
+        mv "$HOME/.ssh/config.tmp" "$HOME/.ssh/config"
+    else
+        printf "Include conf.d/*.conf\n" > "$HOME/.ssh/config"
+    fi
+    chmod 600 "$HOME/.ssh/config"
+fi
+
 # starship
 mkdir -p "$HOME"/.config/sheldon
 ln -snfv "$DIR"/config/starship.toml "$HOME"/.config/starship.toml

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,6 @@ done
 mkdir -p "$HOME"/.ssh/conf.d
 chmod 700 "$HOME"/.ssh/conf.d
 ln -snfv "$DIR"/ssh/conf.d/general.conf "$HOME"/.ssh/conf.d/general.conf
-chmod 600 "$HOME"/.ssh/conf.d/general.conf
 # ~/.ssh/config の先頭に Include がなければ追記
 if ! grep -q "Include conf.d/\*.conf" "$HOME/.ssh/config" 2>/dev/null; then
     if [ -f "$HOME/.ssh/config" ]; then

--- a/ssh/conf.d/general.conf
+++ b/ssh/conf.d/general.conf
@@ -1,0 +1,5 @@
+Host *
+  SetEnv TERM=xterm-256color
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+  AddKeysToAgent yes


### PR DESCRIPTION
## Summary
- `ssh/conf.d/general.conf` を追加し、TERM・ServerAlive・AddKeysToAgent の汎用設定を dotfiles で管理できるようにした
- `install.sh` で `~/.ssh/conf.d/general.conf` へのシンボリックリンク作成と、`~/.ssh/config` への `Include conf.d/*.conf` 追記を自動化（冪等）
- `ssh/conf.d/private*.conf` を `.gitignore` に追加し、機密ホスト定義の誤コミットを防止