### PR TITLE
fix(zsh): ls のファイル名タブ補完が効かない問題を修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,6 +1,6 @@
 # alias
 if command -v eza >/dev/null 2>&1; then
-  alias ls="eza --classify"
+  alias ls="eza --classify=auto"
   alias ll="eza -la --git"
   alias ld="eza -ld" # Show info about the directory
   alias lt="eza -l --sort=modified" # Sort by date, most recent last


### PR DESCRIPTION
## Summary
- eza v0.23.4 で `--classify` が値必須(`=WHEN`)に変わり、値なしの `eza --classify` エイリアスでは zsh の `_eza` 補完が後続の語をフラグの値と誤認し、`ls <ファイル名>` のタブ補完が効かなくなっていた
- エイリアスを `eza --classify=auto` に固定して補完を復旧。`=auto` は TTY 出力時のみ型インジケータを付ける現状の挙動を維持する(パイプ出力を汚さない)