### PR TITLE
chore(claude): curl を Bash deny リストから外す

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -68,7 +68,6 @@
       "Bash(sudo:*)",
       "Bash(terraform apply:*)",
       "Bash(terraform destroy:*)",
-      "Bash(curl:*)",
       "Bash(wget:*)",
       "Bash(cat:*)",
       "Bash(rm -rf:*)",


### PR DESCRIPTION
## Summary

- グローバル権限ポリシー（`~/.claude/settings.json` 実体）で curl をハード deny していたのを解除し、auto モードの classifier 判定に委ねるため
- allow には追加していないため、read-only な HTTP 取得は auto モードで確認なし実行・`curl | bash` や機密データの外部送信は引き続きブロックされる
- 他の deny エントリ（wget / cat / rm -rf / chmod / chown / sudo / terraform apply・destroy）は変更なし

## レビュー所見

`superpowers:requesting-code-review`（独立レビューエージェント）実施済み。

### Critical（修正済み）
- なし

### Important（修正済み）
- コミットメッセージ本文が auto モードの実挙動と食い違っていた（当初「curl は引き続きプロンプト確認される」と記載）。`defaultMode: auto` では read-only な curl は確認なしで実行されるため、auto classifier の挙動に合わせてコミットメッセージを amend 済み。

### Minor（確認済み・方針確定）
- 当初の想定「実行時に確認が入る（安全寄り）」は auto モードでは成立しない（read-only な curl GET は確認なしで走る）。ユーザーに確認し「deny 除外のみ（現状の diff）」で確定。毎回プロンプト確認を強制したい場合は別途 `permissions.ask` に `Bash(curl:*)` を追加する必要がある（今回はスコープ外）。