### PR TITLE
chore(claude): Opus 4.6 フォールバックモデルを追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -232,6 +232,9 @@
     }
   },
   "language": "japanese",
+  "fallbackModel": [
+    "claude-opus-4-6"
+  ],
   "effortLevel": "xhigh",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "stable",


### PR DESCRIPTION
## Summary
- Opus が過負荷・不達のとき Opus 4.6 へ自動フォールバックする `fallbackModel` を追加（Claude Code v2.1.166+ の設定）

## レビュー所見
- **Critical（修正済み・本PRから除外）**: 当初は `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` を「Agent Teams の GA 化で no-op」と判断し削除しようとしたが、公式ドキュメント（v2.1.178 時点）で「このフラグなしでは team が一切セットアップされず teammate も spawn されない」と明記されており、依然として必須と確認。直近リリースで変わったのは「フラグ設定時に TeamCreate/TeamDelete が不要になった」点のみ。削除を撤回し、本PRは `fallbackModel` 追加のみとした。
- **Minor（未対応・許容）**: `fallbackModel` は schemastore の JSON スキーマに未反映のため、`$schema` 参照エディタで未知プロパティ警告が出る可能性あり。Claude Code 本体は v2.1.166+ で対応済みのため動作には影響なし（スキーマ追従待ち）。

### 今回の調査で見送った項目（参考）
- `attribution.sessionUrl`: 公式スキーマ未定義（`additionalProperties:false`）かつ既存 `commit:""`/`pr:""` で trailer 抑止済みの可能性が高く見送り。
- `sandbox.credentials`: `sandbox.enabled:true`（Bash サンドボックス有効化）が前提で、現構成では無効のため見送り。