### PR TITLE
chore: Brewfile に playwright-cli を追加

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -32,6 +32,7 @@ brew "packer"
 brew "graphviz"
 brew "azure-cli"
 brew "cloudflare-wrangler"
+brew "playwright-cli"
 ## modern CLI
 brew "eza"     # ls代替
 brew "fd"      # find代替


### PR DESCRIPTION
## Summary
- `brew bundle` で playwright-cli を導入できるよう Brewfile に追加

## レビュー所見
- Critical / Important: なし（AIレビューで「Ready to merge: Yes」）
- Minor（要判断・未対応）: `playwright-cli` (v0.1.15) は旧来のスタンドアロンCLI。現行の Playwright ツールは `@playwright/test` 同梱の `npx playwright` 側にある。今回は要望どおりのformula名でインストール済みのため対応不要
