### PR TITLE
feat: herdr の workspace 直接移動キーバインドを追加

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -19,6 +19,13 @@ focus_pane_down = "shift+down"
 focus_pane_up = "shift+up"
 focus_pane_right = "shift+right"
 
+# workspace(space)間の直接移動。デフォルトは picker (prefix+w) のみで
+# next/previous が未割り当てのため、tmux の prefix+( / prefix+) 相当を補う
+next_workspace = "prefix+down"
+previous_workspace = "prefix+up"
+# 番号ジャンプ(tab の prefix+1..9 と対になる)
+switch_workspace = "prefix+shift+1..9"
+
 [ui.toast]
 # エージェント状態変化の通知はアプリ内トーストで受ける
 delivery = "herdr"


### PR DESCRIPTION
## Summary
- herdr のデフォルトでは workspace(space)間の移動が picker (`prefix+w`) のみで、tmux のセッション切り替え相当の直接移動ができないため、`next_workspace` / `previous_workspace` / `switch_workspace` を割り当てた
- `prefix+↓/↑` で隣接 workspace へ、`prefix+shift+1..9` で番号ジャンプ(tab の `prefix+1..9` と対になる構成)
- 適用済み: `herdr server reload-config` で diagnostics なしで反映されることを確認済み

## レビュー所見

独立レビュー(requesting-code-review)の結果: Critical / Important なし、承認済み。

- Minor(未対応・要判断): `prefix+shift+1..9` は設定構文としては公式ドキュメントの例と同一だが、shift+数字のキー配送はターミナル・キーボード配列(JIS/US)依存の可能性あり。実際に `prefix` → `shift+2` 等で一度動作確認を推奨。動かない場合の代替は `prefix+alt+1..9` または legacy `[keys.indexed]`
- Minor(認識のみ): config ヘッダのスキーマは v0.7.1 にピン。古い herdr を使う別マシンでは `switch_workspace` キーが未知の可能性(ファイル全体に共通の既存リスク)

https://claude.ai/code/session_01CcdUsNKQeD6q2gK1L1MxJw