### PR TITLE
デフォルトモデルを 1M なし Opus 4.8 に変更しモデル切替エイリアスを追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -42,6 +42,11 @@ alias gstash="git stash"
 alias gwtl="git worktree list"
 alias gwtrm="git worktree remove"
 alias gwtpr="git worktree prune"
+
+# Claude Code モデル切替(デフォルトは settings.json の claude-opus-4-8 = 1M なし)
+alias copus='claude --model claude-opus-4-8'
+alias copus1m='claude --model "claude-opus-4-8[1m]"'
+alias csonnet='claude --model claude-sonnet-5'
 _gwtrm() {
   local -a worktrees
   worktrees=(${(f)"$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')"})

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -108,6 +108,9 @@
     ],
     "defaultMode": "auto"
   },
+  "fallbackModel": [
+    "claude-opus-4-6"
+  ],
   "hooks": {
     "PreToolUse": [
       {
@@ -258,9 +261,6 @@
     }
   },
   "language": "japanese",
-  "fallbackModel": [
-    "claude-opus-4-6"
-  ],
   "effortLevel": "xhigh",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "stable",
@@ -269,5 +269,6 @@
   "theme": "dark",
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "model": "claude-opus-4-8"
 }


### PR DESCRIPTION
## Summary
- Opus 4.8 の既知の停止バグ(thinking→tool_use 遷移の silent stuck-turn)を避けるため、デフォルトモデルを 1M context なしの Opus 4.8 に変更
- 1Mあり Opus / Sonnet 5 を起動時に選べる zsh エイリアス(`copus1m` / `csonnet`)を追加。1Mなし Opus は `copus` および素の `claude`
- settings.json の `fallbackModel` の位置移動は installer 由来の再整形で機能影響なし

## レビュー所見
- Critical / Important / Minor: なし
- 設定値変更と3行のエイリアス追加のためコードレビューエージェントは省略

https://claude.ai/code/session_01FrUdab3ZoGGAtzQFUNEZp3
