### PR TITLE
feat: アドバイザーツールを有効化(メインはデフォルトモデル + Fable 5 アドバイザー)

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -261,6 +261,7 @@
   "fallbackModel": [
     "claude-opus-4-6"
   ],
+  "advisorModel": "opus",
   "effortLevel": "xhigh",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "stable",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -261,7 +261,7 @@
   "fallbackModel": [
     "claude-opus-4-6"
   ],
-  "advisorModel": "opus",
+  "advisorModel": "fable",
   "effortLevel": "xhigh",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "stable",


### PR DESCRIPTION
## なぜ

Opus 4.8 をメインモデルとして使うと挙動が不安定で、Sonnet の方が安定しているため。メインはデフォルトモデルのまま(`model` キーは未設定を維持)、判断ポイントでのみ上位モデルに相談する [advisor tool](https://code.claude.com/docs/en/advisor) 構成に切り替える。

## 変更内容

- `claude/settings.json` に `"advisorModel": "fable"` を追加(1行のみ)
- メインモデルは未設定のまま = デフォルトを使用。方針決定・エラー再発・完了判定などの場面で Fable 5 に相談する

## 注意点

- Fable 5 アドバイザーには Claude Code v2.1.170 以降と組織での Fable 5 アクセスが必要。条件を満たさない環境ではアドバイザーが付与されず、助言なしで通常動作する(エラーにはならない)
- アドバイザー呼び出しは Fable 5 のレートで課金され、サブスクプランでは使用量上限にカウントされる
- Fable 5 が使えない環境では `/advisor opus` または `"advisorModel": "opus"` に切り替え可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEfkGaq6w5M9sWM8XuNPsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEfkGaq6w5M9sWM8XuNPsG)_