### PR TITLE
feat: Brewfile に zizmor を追加

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,6 +23,7 @@ brew "tmux"
 brew "tree"
 brew "trivy"
 brew "actionlint"
+brew "zizmor" # GitHub Actions security scanner
 brew "mycli"
 brew "pgcli"
 brew "pinact"


### PR DESCRIPTION
## Summary
- GitHub Actions のセキュリティスキャナ zizmor を Brewfile に追加(actionlint の隣に配置)
- homebrew-core の formula(v1.26.1)で `brew bundle` により再現可能

## レビュー所見
- Critical / Important / Minor いずれも指摘なし(レビューエージェント承認済み)

https://claude.ai/code/session_01SX8983fLZUzssiLRmdBMZJ