### PR TITLE
feat: crit レビューフローの tmux / herdr 両対応

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -23,7 +23,7 @@
 ## レビューゲート
 
 - 対話セッションで設計/プランファイルを生成・更新したら、実装前に crit レビューを通す(順序: 設計の crit → 実装 → `superpowers:requesting-code-review` → Draft PR)。headless 自走時は Draft PR を人間レビューのゲートとする
-- crit は tmux 内で `crit review <file> --detach --wait`(Bash timeout 600000ms)→ `crit status <file>` のコメントを反映。tmux 外ではブロッキング起動せず手動実行をユーザーに依頼する。TUI 表示中は対象ファイルを編集しない
+- crit は `~/.claude/crit-review.sh <file>`(Bash timeout 600000ms)で起動し、完了後に `crit status <file>` のコメントを反映。スクリプトが tmux / herdr を自動判別して隣ペインに TUI を開く。どちらでもない環境ではスクリプトが失敗するので、ブロッキング起動せず手動実行をユーザーに依頼する。TUI 表示中は対象ファイルを編集しない
 - 可読性を下げる指摘(否定形への反転、抽象化の追加、将来仮定への対応)はそのまま適用せず、該当箇所・指摘要約・代替案(適用しない案を含む)を添えてユーザーの判断を仰ぐ
 - 「CIが通った」「レビューエージェントが承認した」を設計判断の正当性の根拠としない。指摘への反論コメントの投稿は文面の承認を得てから
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -10,6 +10,7 @@ claude/
 ├── settings.json    # グローバル設定（permissions / hooks / statusline / plugins）
 ├── CLAUDE.md        # グローバルプロンプト（全プロジェクト共通ガイドライン）
 ├── statusline.sh    # ステータスライン表示スクリプト
+├── crit-review.sh   # crit レビュー TUI 起動ラッパー（tmux / herdr 対応）
 ├── mcp-setup.sh     # MCPサーバー登録スクリプト
 ├── hooks/           # フックスクリプト
 ├── skills/          # カスタムスキル
@@ -26,6 +27,7 @@ claude/
 | `claude/settings.json` | `~/.claude/settings.json` |
 | `claude/CLAUDE.md` | `~/.claude/CLAUDE.md` |
 | `claude/statusline.sh` | `~/.claude/statusline.sh` |
+| `claude/crit-review.sh` | `~/.claude/crit-review.sh` |
 | `claude/hooks/*.sh` | `~/.claude/hooks/`（個別リンク + `chmod +x`） |
 | `claude/skills/*/` | `~/.claude/skills/`（ディレクトリ単位でリンク） |
 | `claude/agents/*.md` | `~/.claude/agents/`（個別リンク） |
@@ -103,6 +105,20 @@ install.sh が marketplace を登録し、以下をインストールする
 - `superpowers` / `frontend-design` / `context7` / `security-guidance`（anthropics/claude-plugins-official）
 - `terraform-code-generation` / `terraform-module-generation` / `terraform-provider-development`（hashicorp/agent-skills）
 - `crit`（kevindutra/crit）
+
+## crit レビューラッパー
+
+CLAUDE.md のレビューゲートは `crit review` を直接ではなく `crit-review.sh <file>` 経由で
+起動する。crit 本体の `--detach`（TUI を隣ペインに開く機能）が tmux 専用のため、
+ラッパーが実行環境を判別して同じ体験を提供する:
+
+- tmux 内（`$TMUX`）: `crit review <file> --detach --wait` にそのまま委譲
+- herdr 内（`$HERDR_PANE_ID`）: `herdr pane split` で隣ペインを作り TUI を起動、
+  終了マーカーの出力を `herdr wait output` で待つ（`--detach --wait` 相当）
+- どちらでもない: エラー終了し、手動実行を促す
+
+待ち時間の上限は 540000ms（env `CRIT_REVIEW_TIMEOUT_MS` で変更可）。
+herdr フローは `jq` に依存する。
 
 ## Statusline
 

--- a/claude/crit-review.sh
+++ b/claude/crit-review.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# crit のレビュー TUI を tmux / herdr のどちらの環境でも隣ペインに開くラッパー。
+# crit 本体の --detach は tmux 専用のため、herdr では socket API でペインを分割して
+# TUI を起動し、終了マーカーの出力を待つことで --detach --wait 相当を再現する。
+# レビュー完了後のコメント取得は従来どおり呼び出し側で `crit status <file>` を実行する。
+
+set -uo pipefail
+
+FILE="${1:-}"
+if [ -z "$FILE" ]; then
+  echo "usage: crit-review.sh <file>" >&2
+  exit 2
+fi
+
+if ! command -v crit >/dev/null 2>&1; then
+  echo "crit-review: crit が見つかりません（dotfiles の install.sh で導入されます）" >&2
+  exit 127
+fi
+
+# レビュー完了待ちの上限(ms)。呼び出し側の Bash timeout(600000ms)より短くして、
+# タイムアウト時もこのスクリプト自身がエラーを報告して終われるようにする
+WAIT_TIMEOUT_MS="${CRIT_REVIEW_TIMEOUT_MS:-540000}"
+
+# tmux 内(herdr のペインで tmux を起動している場合を含む)は crit 標準の統合に委譲する
+if [ -n "${TMUX:-}" ]; then
+  exec crit review "$FILE" --detach --wait
+fi
+
+if [ -n "${HERDR_PANE_ID:-}" ] && command -v herdr >/dev/null 2>&1; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "crit-review: herdr フローには jq が必要です" >&2
+    exit 127
+  fi
+
+  PANE=$(herdr pane split --pane "$HERDR_PANE_ID" --direction right --cwd "$PWD" --no-focus 2>/dev/null \
+    | jq -r '.result.pane.pane_id // empty')
+  if [ -z "$PANE" ]; then
+    echo "crit-review: herdr ペインの分割に失敗しました" >&2
+    exit 1
+  fi
+
+  # TUI 終了後に「MARKER=<exit code>」を出力させて完了を検知する。pane run で送った
+  # コマンド行自体もペインにエコーされるため、送信文字列側はクォートでマーカーを
+  # 分断し、完成形のマーカーが出力にしか現れないようにする
+  MARKER="CRIT_REVIEW_EXIT"
+  herdr pane run "$PANE" "crit review $(printf '%q' "$FILE"); printf '%s=%s\n' 'CRIT_''REVIEW_EXIT' \"\$?\""
+
+  if ! herdr wait output "$PANE" --match "${MARKER}=" --timeout "$WAIT_TIMEOUT_MS" >/dev/null 2>&1; then
+    echo "crit-review: レビュー完了待ちがタイムアウトしました（ペイン $PANE で TUI が開いたままの可能性があります）" >&2
+    exit 124
+  fi
+
+  RC=$(herdr pane read "$PANE" --source recent-unwrapped --lines 50 2>/dev/null \
+    | grep -oE "${MARKER}=[0-9]+" | tail -1 | cut -d= -f2)
+  if [ -z "$RC" ]; then
+    # マーカーは検知済みなのでレビュー完了として扱い、内容の確認は crit status に委ねる
+    echo "crit-review: 終了コードを取得できませんでした（レビューは完了扱い）" >&2
+    exit 0
+  fi
+  exit "$RC"
+fi
+
+echo "crit-review: tmux / herdr のどちらでもない環境です。別ターミナルで手動実行してください: crit review $FILE" >&2
+exit 1

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -36,6 +36,7 @@
       "Bash(bun:*)",
       "Bash(gh:*)",
       "Bash(go:*)",
+      "Bash(~/.claude/crit-review.sh:*)",
       "Bash(crit review:*)",
       "Bash(crit status:*)",
       "Bash(crit comment:*)",

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ mkdir -p "$HOME"/.claude
 ln -snfv "$DIR"/claude/settings.json "$HOME"/.claude/settings.json
 ln -snfv "$DIR"/claude/CLAUDE.md "$HOME"/.claude/CLAUDE.md
 ln -snfv "$DIR"/claude/statusline.sh "$HOME"/.claude/statusline.sh
+ln -snfv "$DIR"/claude/crit-review.sh "$HOME"/.claude/crit-review.sh
 
 # claude mcp servers
 if command -v claude &> /dev/null; then


### PR DESCRIPTION
## Summary

- crit の `--detach`（TUI を隣ペインに開く機能）は tmux 専用のため、herdr 上で Claude Code を動かすとレビューゲートが機能しなかった
- 環境を自動判別するラッパー `claude/crit-review.sh` を追加: tmux では `crit review --detach --wait` に委譲、herdr では socket API（`pane split` → `pane run` → `wait output`）で同等の挙動を再現し、crit の終了コードも伝播する
- ペインに送るコマンド文字列内では終了マーカーをクォートで分断し、入力エコーが `wait output` に誤マッチしないようにした
- CLAUDE.md のレビューゲートをラッパー経由に変更し、settings.json の allow・install.sh のシンボリックリンク・claude/README.md を追随

## レビュー所見

- ✅ スタブ（crit / herdr のモック）で4分岐（tmux 委譲 / herdr フロー / 非対応環境 / 引数なし）と終了コード伝播を検証済み
- ⚠️ Important（未対応・要判断）: 実機の herdr では未検証。CLI フラグは herdr の agent skill ドキュメントと `.zshrc` の `herdrg` での実績ある使い方に合わせているが、herdr ペイン内で `~/.claude/crit-review.sh <file>` のスモークテスト推奨（反映には `./install.sh` 再実行が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HweberLr2nKiEXKSTZvTM3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HweberLr2nKiEXKSTZvTM3)_