### PR TITLE
chore: デフォルトモデルを fable-5 から Sonnet 5 に変更

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -109,7 +109,7 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "claude-fable-5[1m]",
+  "model": "claude-sonnet-5[1m]",
   "fallbackModel": [
     "claude-opus-4-6"
   ],


### PR DESCRIPTION
## Summary
- デフォルトモデルを `fable-5` から `Sonnet 5`(`claude-sonnet-5[1m]`)へ変更。fable の利用制限が厳しくなるため、メインの消費を fable から移す
- fable は `advisorModel` として残し、advisor 呼び出し時のみ使う形で消費を抑制(既存設定を維持)
- `effortLevel: "xhigh"` は維持。Sonnet 5 は xhigh をネイティブサポートするため、そのまま最上位の thinking が効く
