### PR TITLE
commit / PR から Claude session URL を除去

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -6,7 +6,8 @@
   },
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Summary
- `attribution.sessionUrl: false` を追加し、commit trailer と PR 本文への claude.ai セッションリンク付与を止める
- `attribution.commit` / `attribution.pr` を空にするだけでは session URL は別フラグ扱いのため残っていた

## レビュー所見
- Critical: なし
- Important / Minor: なし(設定キー1個の追加のみ)