### PR TITLE
herdr が漏らす OSC 応答を ZLE 側で捨てる

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -74,35 +74,39 @@ gwta() {
 ## tmux
 alias tmuxg='tmux new-session \; source-file ~/.tmux.session.conf'
 ## herdr
-# herdr の TUI は起動時に端末へカラークエリ(OSC 10/11/4)を送るが応答を読み切らずに終了する。
-# 残りが次のプロンプトに文字として流れ込むため、復帰後に端末の入力キューを捨てる。
-# 既に画面へエコーされた分は消せないので対象外。
-# nomultibyte にしないと、キューが不完全なマルチバイト文字で終わった時に read -k が固まる
-herdr() {
-  command herdr "$@"
-  local ret=$?
-  if [[ -t 0 ]]; then
-    setopt localoptions nomultibyte
-    local discard
-    while read -t 0.1 -k 1 -s discard 2>/dev/null; do :; done
-  fi
-  return $ret
+# herdr は起動時にホスト端末へカラークエリ(OSC 4/10/11)を投げるが、返ってきた応答を
+# 自分で読み切らずペインの pty へ素通しする。応答はプロンプトに文字として打ち込まれ、
+# Enter で `command not found: 4` のように実行されてしまう。
+# ZLE に ESC ] が届いたら終端(ST または BEL)まで読み捨てて、行バッファへの混入を防ぐ。
+# 到着時刻が読めないので、herdr 終了後にまとめてキューを捨てる方式では捕まえられない。
+# ZLE 起動前に届いた分は端末がエコー済みで表示だけ残るが、実行される危険はない。
+_herdr-discard-osc-response() {
+  local c
+  # 終端を返さない端末で固まらないよう、無音 0.2 秒で打ち切る
+  while read -t 0.2 -k 1 -s c; do
+    [[ $c == $'\a' ]] && return
+    if [[ $c == $'\e' ]]; then
+      read -t 0.2 -k 1 -s c || return
+      [[ $c == '\' ]] && return
+    fi
+  done
 }
+zle -N _herdr-discard-osc-response
+bindkey '\e]' _herdr-discard-osc-response
 # herdr のペイン内で実行すると、現在のタブを tmuxg と同じ4ペインレイアウトにする
 # (上60%メイン、下段は左1 + 右上下2)。分割ペインは実行ペインの cwd を継承する
 herdrg() {
   local main p2 p3
-  # pane サブコマンドはカラークエリを送らないので、上のドレイン付きラッパーを迂回する
-  main=$(command herdr pane current 2>/dev/null | jq -r '.result.pane.pane_id // empty')
+  main=$(herdr pane current 2>/dev/null | jq -r '.result.pane.pane_id // empty')
   if [[ -z "$main" ]]; then
     echo "herdrg: herdr ペイン内で実行してください(herdr 未起動の可能性もあります)" >&2
     return 1
   fi
-  p2=$(command herdr pane split --pane "$main" --direction down --ratio 0.6 --cwd "$PWD" --no-focus | jq -r '.result.pane.pane_id // empty')
+  p2=$(herdr pane split --pane "$main" --direction down --ratio 0.6 --cwd "$PWD" --no-focus | jq -r '.result.pane.pane_id // empty')
   [[ -n "$p2" ]] || { echo "herdrg: 分割に失敗しました" >&2; return 1; }
-  p3=$(command herdr pane split --pane "$p2" --direction right --ratio 0.5 --cwd "$PWD" --no-focus | jq -r '.result.pane.pane_id // empty')
+  p3=$(herdr pane split --pane "$p2" --direction right --ratio 0.5 --cwd "$PWD" --no-focus | jq -r '.result.pane.pane_id // empty')
   [[ -n "$p3" ]] || { echo "herdrg: 分割に失敗しました" >&2; return 1; }
-  command herdr pane split --pane "$p3" --direction down --ratio 0.5 --cwd "$PWD" --no-focus >/dev/null
+  herdr pane split --pane "$p3" --direction down --ratio 0.5 --cwd "$PWD" --no-focus >/dev/null
 }
 ## pipe
 alias -g L='| less'

--- a/.zshrc
+++ b/.zshrc
@@ -79,8 +79,11 @@ alias tmuxg='tmux new-session \; source-file ~/.tmux.session.conf'
 # Enter で `command not found: 4` のように実行されてしまう。
 # ZLE に ESC ] が届いたら終端(ST または BEL)まで読み捨てて、行バッファへの混入を防ぐ。
 # 到着時刻が読めないので、herdr 終了後にまとめてキューを捨てる方式では捕まえられない。
-# ZLE 起動前に届いた分は端末がエコー済みで表示だけ残るが、実行される危険はない。
+# ZLE が素の行編集状態にない間(起動前・ブラケットペースト中)に届いた分は取りこぼす。
+# 起動前の分は端末がエコー済みで表示だけ残り、実行される危険はない。
 _herdr-discard-osc-response() {
+  # マルチバイト解釈が入ると、終端の ESC \ が継続バイトとして食われて抜けられなくなる
+  setopt localoptions nomultibyte
   local c
   # 終端を返さない端末で固まらないよう、無音 0.2 秒で打ち切る
   while read -t 0.2 -k 1 -s c; do


### PR DESCRIPTION
## Summary
- herdr がカラークエリの応答を消費せずペインへ素通しするため、応答がプロンプトに打ち込まれて Enter で実行されていた
- 応答の到着時刻が読めず #84 の「herdr 終了後にキューを捨てる」方式は発火しないことを実測で確認したので、その wrapper を削除する
- 代わりに `\e]` に ZLE ウィジェットを束縛し、OSC 終端まで読み捨てて行バッファへの混入を断つ