### PR TITLE
効いていないシェル設定を削除する

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -119,12 +119,6 @@ alias -g G='| grep -E'
 alias -g W='| wc -l'
 alias -g B='| base64 --decode | gpg -d'
 
-# ssh configを読み込む
-function _ssh {
-  # compadd `fgrep 'Host ' ~/.ssh/config | awk '{print $2}' | sort`;
-  compadd `find ~/.ssh/* -type file | xargs fgrep 'Host ' | awk '{print $2}' | sort`;
-}
-
 # gcloud
 GCLOUD_SDK_PATH="/opt/homebrew/Caskroom/gcloud-cli/latest/google-cloud-sdk"
 [[ -f "$GCLOUD_SDK_PATH/path.zsh.inc" ]] && source "$GCLOUD_SDK_PATH/path.zsh.inc"
@@ -140,8 +134,6 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # asdf
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
-## nom install
-## ln -s .asdf/shims/claude "$HOME/.asdf/installs/nodejs/24.1.0/bin/claude"
 
 # kubectl
 if command -v kubectl >/dev/null 2>&1; then

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -29,9 +29,6 @@ github = "romkatv/zsh-defer"
 [plugins.brew-completion]
 inline = 'type brew &>/dev/null && FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"'
 
-# [plugins.rust-zsh-completions]
-# github = "ryutok/rust-zsh-completions"
-
 [plugins.zsh-completions]
 github = "zsh-users/zsh-completions"
 

--- a/config/starship.toml
+++ b/config/starship.toml
@@ -78,6 +78,3 @@ format = "[$user 🌱]($style) "
 show_always = true
 style_root = "black bold"
 style_user = "white bold"
-
-[time]
-disabled = true


### PR DESCRIPTION
## Summary
- ローカルの `_ssh` が zsh 標準の ssh 補完を壊れた実装で上書きしていたため削除する
- 参照先が消えている asdf のメモと、コメントアウトされたままの sheldon プラグインを削除する
- starship の `[time]` は `$time` が `format` に無く描画されないため削除する