### PR TITLE
gopls-lsp プラグインを install.sh に追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -246,7 +246,8 @@
     "frontend-design@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "crit@crit": true
+    "crit@crit": true,
+    "gopls-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "hashicorp": {

--- a/install.sh
+++ b/install.sh
@@ -125,6 +125,7 @@ if command -v claude &> /dev/null; then
     claude plugin install frontend-design@claude-plugins-official
     claude plugin install context7@claude-plugins-official
     claude plugin install security-guidance@claude-plugins-official
+    claude plugin install gopls-lsp@claude-plugins-official
 
     # HashiCorp Terraform plugins
     claude plugin install terraform-code-generation@hashicorp


### PR DESCRIPTION
## Summary
- `enabledPlugins` の有効化だけでは新環境にプラグイン本体が入らないため、`install.sh` に `gopls-lsp` のインストールを追加
- `claude/settings.json` の `enabledPlugins` に `gopls-lsp@claude-plugins-official` を追記