### PR TITLE
fallback モデルを sonnet[1m] に変更する

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -111,9 +111,8 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "opus",
   "fallbackModel": [
-    "claude-opus-4-6"
+    "sonnet[1m]"
   ],
   "hooks": {
     "PreToolUse": [
@@ -279,5 +278,7 @@
   "theme": "dark",
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "switchModelsOnFlag": true,
+  "model": "opus[1m]"
 }


### PR DESCRIPTION
## Summary
- ピン留めの `claude-opus-4-6` が陳腐化していたため、fallbackModel をエイリアス表記の `sonnet[1m]` に変更した。
- `[1m]` を付けたのは、プライマリが 1M コンテキストで 200k を超えたセッションでも fallback を成立させるため。
- harness が `/model` と `/config` でファイルに直接書いた `model` と `switchModelsOnFlag` を、そのままコミットした。
