### PR TITLE
hashicorp marketplace の統合に追従してプラグイン識別子を更新する

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -102,7 +102,7 @@ Notification / Stop 通知）を設定している。
 install.sh が marketplace を登録し、以下をインストールする
 （`settings.json` の `enabledPlugins` / `extraKnownMarketplaces` と対応）:
 
-- `superpowers` / `frontend-design` / `context7` / `security-guidance`（anthropics/claude-plugins-official）
+- `superpowers` / `frontend-design` / `context7` / `security-guidance` / `gopls-lsp`（anthropics/claude-plugins-official）
 - `terraform`（hashicorp/agent-skills）
 - `crit`（tomasz-tomczyk/crit）
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -103,7 +103,7 @@ install.sh が marketplace を登録し、以下をインストールする
 （`settings.json` の `enabledPlugins` / `extraKnownMarketplaces` と対応）:
 
 - `superpowers` / `frontend-design` / `context7` / `security-guidance`（anthropics/claude-plugins-official）
-- `terraform-code-generation` / `terraform-module-generation` / `terraform-provider-development`（hashicorp/agent-skills）
+- `terraform`（hashicorp/agent-skills）
 - `crit`（tomasz-tomczyk/crit）
 
 ## crit

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -239,9 +239,7 @@
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
-    "terraform-code-generation@hashicorp": true,
-    "terraform-module-generation@hashicorp": true,
-    "terraform-provider-development@hashicorp": true,
+    "terraform@hashicorp": true,
     "frontend-design@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,

--- a/install.sh
+++ b/install.sh
@@ -164,10 +164,8 @@ if command -v claude &> /dev/null; then
     claude plugin install security-guidance@claude-plugins-official
     claude plugin install gopls-lsp@claude-plugins-official
 
-    # HashiCorp Terraform plugins
-    claude plugin install terraform-code-generation@hashicorp
-    claude plugin install terraform-module-generation@hashicorp
-    claude plugin install terraform-provider-development@hashicorp
+    # HashiCorp Terraform plugin
+    claude plugin install terraform@hashicorp
 
     # crit review plugin
     claude plugin install crit@crit


### PR DESCRIPTION
## Summary
- hashicorp/agent-skills が旧3プラグイン識別子を廃止し `terraform` に統合したため、install.sh が毎回インストールに失敗していた
- `install.sh` / `claude/settings.json` / `claude/README.md` の識別子を `terraform@hashicorp` に揃えた
- README のプラグイン一覧に漏れていた `gopls-lsp` を追記した