### PR TITLE
co の行を、成果物を作ったセッションに紐付ける

### DIFF
--- a/bin/claude-outputs
+++ b/bin/claude-outputs
@@ -227,8 +227,8 @@ awk -F"$SEP" -v sep="$SEP" '!seen[$1]++ { print $1 sep $3 }' "$T/urls" > "$T/sid
 # セッションの transcript にも URL は残る。言及だけで決めると sort 順の都合で
 # session_id の小さい無関係なセッションが行を攫っていく。
 #
-# Why not 全ファイルに jq: transcript は1本で数MBある。作成の痕跡が無いファイルは
-# grep で先に落とす(46本 → 25本)。
+# Why not URL を含む全ファイルに jq: transcript は1本で数MBある。作成の痕跡が無い
+# ファイルを grep で先に落とすと、走査対象がおおむね半分になる。
 awk -F"$SEP" -v sep="$SEP" '!seen[$1 sep $3]++ { print $1 sep $3 }' "$T/urls" \
     > "$T/scan_pairs"
 
@@ -236,7 +236,9 @@ awk -F"$SEP" -v sep="$SEP" '!seen[$1 sep $3]++ { print $1 sep $3 }' "$T/urls" \
 : > "$T/art_titles"  # url / 説明文
 while IFS="$SEP" read -r sid f; do
     [ -f "$f" ] || continue
-    grep -q -e 'gh pr create' -e '"name":"Artifact"' "$f" 2>/dev/null || continue
+    # Why not "name":"Artifact": JSON の空白の入り方に依存する。絞り込みが目的なので
+    # ツール名だけで足りる(外れても jq 側の条件で落ちる)。
+    grep -q -e 'gh pr create' -e '"Artifact"' "$f" 2>/dev/null || continue
     # Why not gsub で content 全体を整形: tool_result は巨大になりうる。URL だけ
     # scan で抜けば、同じ走査が桁で速くなる。
     jq -r --arg sep "$SEP" --arg sid "$sid" '
@@ -264,7 +266,8 @@ while IFS="$SEP" read -r sid f; do
 done < "$T/scan_pairs" \
     | awk -F"$SEP" -v sep="$SEP" -v ownerfile="$T/owners" -v titlefile="$T/art_titles" '
         $1 == "T" { kind[$2] = $3; label[$2] = $4 }
-        # artifact は publish のたびに説明文が変わるので、最後に見たものを採る。
+        # artifact は publish のたびに説明文が変わるので、後に来たもので上書きする。
+        # 1セッション内では publish 順に並ぶので、これが最新の説明文になる。
         $1 == "R" && ($2 in kind) {
             n = split($4, us, " ")
             for (i = 1; i <= n; i++) {

--- a/bin/claude-outputs
+++ b/bin/claude-outputs
@@ -217,43 +217,66 @@ fi
 # session_id -> transcript のパス(repo 名を引くときの入口)
 awk -F"$SEP" -v sep="$SEP" '!seen[$1]++ { print $1 sep $3 }' "$T/urls" > "$T/sid_paths"
 
-# ---- artifact の説明文を URL に紐付ける -----------------------------------
-# tool_use.id と tool_result.tool_use_id で対応させる。read や list で触っただけの
-# artifact は publish の tool_use を持たないので、ここで自然に外れる。
-awk -F"$SEP" '$2 ~ /claude\.ai\/code\/artifact\// { print $3 }' "$T/urls" \
-    | sort -u > "$T/art_files"
+# ---- 成果物を作ったセッションを特定する -----------------------------------
+# tool_use.id と tool_result.tool_use_id で対応させ、実際に gh pr create /
+# Artifact publish を走らせたセッションだけを持ち主にする。ついでに artifact の
+# 説明文も引く(read や list で触っただけの artifact は publish の tool_use を
+# 持たないので、ここで自然に外れる)。
+#
+# Why not URL に言及したセッション: 一覧を眺めた・レビューした・co を実行した
+# セッションの transcript にも URL は残る。言及だけで決めると sort 順の都合で
+# session_id の小さい無関係なセッションが行を攫っていく。
+#
+# Why not 全ファイルに jq: transcript は1本で数MBある。作成の痕跡が無いファイルは
+# grep で先に落とす(46本 → 25本)。
+awk -F"$SEP" -v sep="$SEP" '!seen[$1 sep $3]++ { print $1 sep $3 }' "$T/urls" \
+    > "$T/scan_pairs"
 
-: > "$T/art_titles"
-if [ -s "$T/art_files" ]; then
-    while IFS= read -r f; do
-        [ -f "$f" ] || continue
-        jq -r --arg sep "$SEP" '
-            select(.message.content != null)
-            | .message.content[]?
-            | if (.type == "tool_use" and .name == "Artifact"
-                  and ((.input.action // "publish") == "publish")) then
-                  "T\($sep)\(.id // "")\($sep)\(
-                      (.input.description // .input.title // .input.file_path // "")
-                      | tostring | gsub("\\s+"; " ")
-                  )"
-              elif (.type == "tool_result" and .tool_use_id != null) then
-                  "R\($sep)\(.tool_use_id)\($sep)\(.content | tostring | gsub("\\s+"; " "))"
-              else empty end
-        ' "$f" 2>/dev/null
-    done < "$T/art_files" \
-        | awk -F"$SEP" -v sep="$SEP" '
-            $1 == "T" { title[$2] = $3 }
-            $1 == "R" {
-                s = $3
-                while (match(s, /https:\/\/claude\.ai\/code\/artifact\/[0-9a-fA-F-]+/)) {
-                    u = substr(s, RSTART, RLENGTH)
-                    if ($2 in title) map[u] = title[$2]
-                    s = substr(s, RSTART + RLENGTH)
-                }
+: > "$T/owners"      # url / session_id
+: > "$T/art_titles"  # url / 説明文
+while IFS="$SEP" read -r sid f; do
+    [ -f "$f" ] || continue
+    grep -q -e 'gh pr create' -e '"name":"Artifact"' "$f" 2>/dev/null || continue
+    # Why not gsub で content 全体を整形: tool_result は巨大になりうる。URL だけ
+    # scan で抜けば、同じ走査が桁で速くなる。
+    jq -r --arg sep "$SEP" --arg sid "$sid" '
+        select(.message.content != null)
+        | .message.content[]?
+        | if (.type == "tool_use" and .name == "Artifact"
+              and ((.input.action // "publish") == "publish")) then
+              "T\($sep)\(.id // "")\($sep)art\($sep)\(
+                  (.input.description // .input.title // .input.file_path // "")
+                  | tostring | gsub("\\s+"; " ")
+              )"
+          elif (.type == "tool_use" and .name == "Bash"
+                and ((.input.command // "") | test("gh pr create"))) then
+              "T\($sep)\(.id // "")\($sep)pr\($sep)"
+          elif (.type == "tool_result" and .tool_use_id != null) then
+              (.tool_use_id as $id
+               | [ (.content | tostring)
+                   | scan("https://github\\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+|https://claude\\.ai/code/artifact/[0-9a-fA-F-]+")
+                 ]
+               | if length > 0 then
+                     "R\($sep)\($id)\($sep)\($sid)\($sep)\(join(" "))"
+                 else empty end)
+          else empty end
+    ' "$f" 2>/dev/null
+done < "$T/scan_pairs" \
+    | awk -F"$SEP" -v sep="$SEP" -v ownerfile="$T/owners" -v titlefile="$T/art_titles" '
+        $1 == "T" { kind[$2] = $3; label[$2] = $4 }
+        # artifact は publish のたびに説明文が変わるので、最後に見たものを採る。
+        $1 == "R" && ($2 in kind) {
+            n = split($4, us, " ")
+            for (i = 1; i <= n; i++) {
+                owner[us[i]] = $3
+                if (kind[$2] == "art") arttitle[us[i]] = label[$2]
             }
-            END { for (u in map) print u sep map[u] }
-        ' > "$T/art_titles"
-fi
+        }
+        END {
+            for (u in owner)    print u sep owner[u]    > ownerfile
+            for (u in arttitle) print u sep arttitle[u] > titlefile
+        }
+    '
 
 # ---- PR の結果を回収 ------------------------------------------------------
 : > "$T/live_prs"
@@ -287,23 +310,28 @@ fi
 # 既知の限界: GitHub の検索インデックスは非同期なので、作られた直後の PR は
 # gh search prs に現れず、この交差から落ちる。塞ぐなら交差を置き換えるのではなく、
 # 漏れた URL だけを gh pr view で author 照合して足す。
+#
+# session_id は作った証跡から引く。証跡が無い PR(手で作った・7日より前に作った等)は
+# 空のまま出す。ctrl-o は使えないが、行を落とすより無関係なセッションを開かない方がよい。
 awk -F"$SEP" -v sep="$SEP" '
     FILENAME == ARGV[1] { state[$1] = $2; repo[$1] = $3; title[$1] = $4; next }
+    FILENAME == ARGV[2] { owner[$1] = $2; next }
     ($2 in state) {
         if (seen[$2]++) next
-        print "pr" sep state[$2] sep repo[$2] sep title[$2] sep $2 sep $1
+        print "pr" sep state[$2] sep repo[$2] sep title[$2] sep $2 sep owner[$2]
     }
-' "$T/live_prs" "$T/urls" >> "$T/rows"
+' "$T/live_prs" "$T/owners" "$T/urls" >> "$T/rows"
 
 # artifact: publish の説明文が引けたものだけを出す。
 awk -F"$SEP" -v sep="$SEP" '
     FILENAME == ARGV[1] { title[$1] = $2; next }
+    FILENAME == ARGV[2] { owner[$1] = $2; next }
     $2 ~ /claude\.ai\/code\/artifact\// {
         if (!($2 in title)) next
         if (seen[$2]++) next
-        print "artifact" sep "" sep "" sep title[$2] sep $2 sep $1
+        print "artifact" sep "" sep "" sep title[$2] sep $2 sep owner[$2]
     }
-' "$T/art_titles" "$T/urls" >> "$T/rows"
+' "$T/art_titles" "$T/owners" "$T/urls" >> "$T/rows"
 
 # crit: セッション JSON は終了後も残るので、生きているものだけに絞る。
 port_open() {


### PR DESCRIPTION
## Summary
- 行の session_id が「URL に言及したセッションのうち id が辞書順で最小のもの」になっており、無関係なセッションを ctrl-o で開いていた。
- `gh pr create` / Artifact publish の tool_use と、URL を含む tool_result を突き合わせて、作ったセッションを持ち主にする。
- 作成の痕跡が無い行は session_id を空にして、間違ったセッションを開くより ctrl-o を諦める。