### PR TITLE
tmux の上ペインで herdr を起動する

### DIFF
--- a/.tmux.session.conf
+++ b/.tmux.session.conf
@@ -1,0 +1,15 @@
+# tmux session layout configuration
+# Usage: .zshrc の tmuxg 関数から source-file される
+#
+# Layout:
+#   +-----------------------------+
+#   |       pane 1 (herdr)        |
+#   +-----------------------------+
+#   |       pane 2 (shell)        |
+#   +-----------------------------+
+
+# herdr はペインの直接の子プロセスとして起動する。send-keys で流し込むと
+# zsh+sheldon の初期化が終わる前にキーが飛んで取りこぼす。
+# -b で既存ペインの上に作り、-d でフォーカスは下のシェルに残す。
+# -t を省くと分割先が「現在のセッション」になり、別セッションを巻き込むので固定する
+splitw -v -b -d -l 60% -t '=main:' -c "#{pane_current_path}" 'herdr'

--- a/.zshrc
+++ b/.zshrc
@@ -72,9 +72,15 @@ gwta() {
   fi
 }
 ## tmux
-# iTerm2 の分割ペインで起動する常用シェル。-A で既存の main に再アタッチし、
-# ウィンドウを開き直すたびに無名セッションが積み上がるのを防ぐ
-alias tmuxg='tmux new-session -A -s main'
+# iTerm2 の起動時に走る。main があれば attach のみ、無ければ作ってレイアウトを流す。
+# new-session -A だと再アタッチのたびに source-file が走ってペインが増える
+tmuxg() {
+  if tmux has-session -t =main 2>/dev/null; then
+    tmux attach -t =main
+  else
+    tmux new-session -s main \; source-file ~/.tmux.session.conf
+  fi
+}
 ## herdr
 # herdr のペイン内で実行すると、現在のタブを4ペインレイアウトにする
 # (上60%メイン、下段は左1 + 右上下2)。分割ペインは実行ペインの cwd を継承する

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ install.sh は再実行可能（リンクは `ln -snf` で張り直されるた�
 
 | パス | 配置先 | 内容 |
 |---|---|---|
-| `.zshrc` / `.tmux.conf` / `.vimrc` | `~/` | シェル・tmux・vim |
+| `.zshrc` / `.tmux.conf` / `.tmux.session.conf` / `.vimrc` | `~/` | シェル・tmux・vim |
 | `bin/` | `~/.local/bin/` | 自作コマンド（`claude-outputs`: 並行セッションの成果物一覧） |
 | `config/starship.toml` | `~/.config/` | プロンプト（starship） |
 | `config/sheldon/plugins.toml` | `~/.config/sheldon/` | zsh プラグイン管理（sheldon） |


### PR DESCRIPTION
## Summary
- iTerm2 側での分割が実運用で機能しなかったため、分割を tmux に戻し上60%で herdr を起動する
- herdr はペインの直接の子プロセスとして起動し、send-keys が zsh 初期化前に飛ぶレースを避ける
- `tmuxg` を関数化し、再アタッチのたびに `source-file` が走ってペインが増えるのを防ぐ