### PR TITLE
auto mode と衝突する Bash(cat:*) の deny を外す

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -75,7 +75,6 @@
       "Bash(crit unpublish:*)",
       "Bash(crit auth:*)",
       "Bash(wget:*)",
-      "Bash(cat:*)",
       "Bash(rm -rf:*)",
       "Bash(chmod:*)",
       "Bash(chown:*)",


### PR DESCRIPTION
## Summary

`permissions.deny` から `Bash(cat:*)` を削除する。

auto mode は既定でファイルを `cat` で読むよう指示するため、このルールがセッション冒頭の通常の読み取りを拒否していた。保護目的では冗長で、`Read(**/.env*)` 系の deny が同じパスに対して `cat` / `head` / `grep` を等しく拒否することを実測で確認済み。削除しても防御は減らない。