### PR TITLE
使用量の固定オーバーヘッドを削る

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -49,6 +49,7 @@ claude/
 | chrome-devtools | ブラウザ操作・DevTools連携 | npx（バージョンピン留め） |
 | context7 | ライブラリドキュメント検索 | npx（バージョンピン留め） |
 | drawio | 図の生成・編集 | npx（バージョンピン留め） |
+| notion | Notion連携 | HTTP（`https://mcp.notion.com/mcp`） |
 | aws | AWS API操作（SigV4認証） | uvx `mcp-proxy-for-aws`（要 `brew install uv`） |
 
 - user スコープで登録したサーバーは登録した時点で有効になる

--- a/claude/README.md
+++ b/claude/README.md
@@ -48,9 +48,7 @@ claude/
 | serena | コード解析・シンボル検索 | docker（`~/ghq` をマウント） |
 | chrome-devtools | ブラウザ操作・DevTools連携 | npx（バージョンピン留め） |
 | context7 | ライブラリドキュメント検索 | npx（バージョンピン留め） |
-| playwright | E2E・ブラウザ自動化 | npx（バージョンピン留め） |
 | drawio | 図の生成・編集 | npx（バージョンピン留め） |
-| notion | Notion連携 | HTTP（`https://mcp.notion.com/mcp`） |
 | aws | AWS API操作（SigV4認証） | uvx `mcp-proxy-for-aws`（要 `brew install uv`） |
 
 - user スコープで登録したサーバーは登録した時点で有効になる
@@ -102,7 +100,7 @@ Notification / Stop 通知）を設定している。
 install.sh が marketplace を登録し、以下をインストールする
 （`settings.json` の `enabledPlugins` / `extraKnownMarketplaces` と対応）:
 
-- `superpowers` / `frontend-design` / `context7` / `security-guidance` / `gopls-lsp`（anthropics/claude-plugins-official）
+- `superpowers` / `frontend-design` / `security-guidance` / `gopls-lsp`（anthropics/claude-plugins-official）
 - `terraform`（hashicorp/agent-skills）
 - `crit`（tomasz-tomczyk/crit）
 

--- a/claude/mcp-setup.sh
+++ b/claude/mcp-setup.sh
@@ -18,14 +18,8 @@ claude mcp add chrome-devtools --scope user \
 claude mcp add context7 --scope user \
     -- npx -y @upstash/context7-mcp@3.2.0
 
-claude mcp add playwright --scope user \
-    -- npx -y @executeautomation/playwright-mcp-server@1.0.12
-
 claude mcp add drawio --scope user \
     -- npx -y @drawio/mcp@1.2.7
-
-claude mcp add notion --transport http --scope user \
-    https://mcp.notion.com/mcp
 
 # AWS MCP Server (GA: https://aws.amazon.com/jp/blogs/aws/the-aws-mcp-server-is-now-generally-available/)
 # Proxy: https://github.com/aws/mcp-proxy-for-aws (official, Apache-2.0)

--- a/claude/mcp-setup.sh
+++ b/claude/mcp-setup.sh
@@ -21,6 +21,9 @@ claude mcp add context7 --scope user \
 claude mcp add drawio --scope user \
     -- npx -y @drawio/mcp@1.2.7
 
+claude mcp add notion --transport http --scope user \
+    https://mcp.notion.com/mcp
+
 # AWS MCP Server (GA: https://aws.amazon.com/jp/blogs/aws/the-aws-mcp-server-is-now-generally-available/)
 # Proxy: https://github.com/aws/mcp-proxy-for-aws (official, Apache-2.0)
 # Requires: uv (https://astral.sh/uv) and configured AWS credentials (IAM SigV4 auth)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -270,7 +270,7 @@
     }
   },
   "language": "japanese",
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "advisorModel": "fable",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "stable",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -56,7 +56,6 @@
       "mcp__chrome-devtools__*",
       "mcp__serena__*",
       "mcp__context7__*",
-      "mcp__playwright__*",
       "mcp__aws__*",
       "WebSearch",
       "WebFetch",
@@ -246,7 +245,6 @@
     "superpowers@claude-plugins-official": true,
     "terraform@hashicorp": true,
     "frontend-design@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "crit@crit": true,
     "gopls-lsp@claude-plugins-official": true
@@ -272,7 +270,7 @@
     }
   },
   "language": "japanese",
-  "effortLevel": "xhigh",
+  "effortLevel": "high",
   "advisorModel": "fable",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "stable",

--- a/codex/README.md
+++ b/codex/README.md
@@ -91,7 +91,7 @@ hooks = true
 js_repl = false
 ```
 
-MCP サーバー(serena / context7 / playwright など)は Claude Code 側にのみ登録して
+MCP サーバー(serena / context7 / chrome-devtools など)は Claude Code 側にのみ登録して
 いる。Codex でも必要になったら `codex mcp add` で登録する。
 
 ## rules

--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,6 @@ if command -v claude &> /dev/null; then
     # Anthropic official plugins
     claude plugin install superpowers@claude-plugins-official
     claude plugin install frontend-design@claude-plugins-official
-    claude plugin install context7@claude-plugins-official
     claude plugin install security-guidance@claude-plugins-official
     claude plugin install gopls-lsp@claude-plugins-official
 


### PR DESCRIPTION
## Summary
- 30日分のトランスクリプト実測で、トークン消費の84%がコンテキストの再送であり、全APIコールに31kの固定オーバーヘッドが乗っていた
- 重複していたMCP登録を一本化した(context7 は直登録を残しプラグインを無効化、playwright は chrome-devtools と重複)