### PR TITLE
co の PR 一覧を pr-link レコードから作る

### DIFF
--- a/bin/claude-outputs
+++ b/bin/claude-outputs
@@ -14,7 +14,7 @@ usage() {
     cat <<'USAGE'
 claude-outputs — 並行する Claude セッションの「まだ開くべき成果物」を一覧する
 
-  PR    transcript に出た PR URL のうち、自分が作った open なもの
+  PR    セッションが作った PR のうち、まだ open なもの
   crit  デーモンが生きていて、対応済みになっていない crit レビュー
   art   セッションが publish した artifact
 
@@ -189,12 +189,12 @@ if [ "${HERDR_ENV:-}" = 1 ] && command -v herdr >/dev/null 2>&1; then
     ' > "$T/sessions" 2>/dev/null || : > "$T/sessions"
 fi
 
-# ---- transcript から URL を抽出 -------------------------------------------
+# ---- transcript から artifact の URL を抽出 -------------------------------
 # grep は1プロセスにまとめる(-H でファイル名を残し、そこから session_id を得る)。
-: > "$T/urls"
+: > "$T/art_urls"
 if [ -d "$PROJECTS_DIR" ]; then
     find "$PROJECTS_DIR" -name '*.jsonl' -mtime -"$DAYS" -exec grep -oHE \
-        'https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+|https://claude\.ai/code/artifact/[0-9a-fA-F-]+' \
+        'https://claude\.ai/code/artifact/[0-9a-fA-F-]+' \
         {} + 2>/dev/null \
         | awk -v sep="$SEP" '
             # "<path>/<session_id>.jsonl:<url>" を session_id / url / path に割る。
@@ -211,34 +211,62 @@ if [ -d "$PROJECTS_DIR" ]; then
                 else                                     sid = seg[n]
                 print sid sep url sep path ".jsonl"
             }
-        ' | sort -u > "$T/urls"
+        ' | sort -u > "$T/art_urls"
 fi
 
-# session_id -> transcript のパス(repo 名を引くときの入口)
-awk -F"$SEP" -v sep="$SEP" '!seen[$1]++ { print $1 sep $3 }' "$T/urls" > "$T/sid_paths"
+# ---- transcript から PR の証跡を抽出 --------------------------------------
+# gh pr create が成功すると Claude Code が transcript に pr-link レコードを書く
+# ({"type":"pr-link","sessionId":…,"prUrl":…})。作った本人が残す一次証跡なので、
+# tool_use と tool_result を突き合わせて持ち主を推定する必要がない。
+#
+# Why not 全文に jq: transcript は1本で数MBある。grep で該当行だけ取り出して渡すと、
+# jq が読むのは1ファイルあたり数行で済む。
+: > "$T/pr_links"
+if [ -d "$PROJECTS_DIR" ]; then
+    find "$PROJECTS_DIR" -name '*.jsonl' -mtime -"$DAYS" \
+        -exec grep -lE '"type": *"pr-link"' {} + 2>/dev/null \
+        | while IFS= read -r f; do
+            grep -E '"type": *"pr-link"' "$f" 2>/dev/null \
+                | jq -r --arg sep "$SEP" --arg path "$f" '
+                    select(.type == "pr-link" and .prUrl != null and .sessionId != null)
+                    | [ .prUrl, .sessionId, (.timestamp // ""), $path ] | join($sep)
+                ' 2>/dev/null
+          done \
+        | awk -F"$SEP" -v sep="$SEP" '
+            # 同じ PR に複数のレコードが付く(1つの PR につき十数件書かれる)。
+            # 同じ URL を複数のセッションが指す場合は、最後に紐付いたセッションを採る。
+            # timestamp は ISO8601 の Z 固定なので文字列比較で新しい方が勝つ。
+            $3 >= ts[$1] { ts[$1] = $3; sid[$1] = $2; path[$1] = $4 }
+            END { for (u in sid) print u sep sid[u] sep path[u] }
+        ' > "$T/pr_links"
+fi
 
-# ---- 成果物を作ったセッションを特定する -----------------------------------
-# tool_use.id と tool_result.tool_use_id で対応させ、実際に gh pr create /
-# Artifact publish を走らせたセッションだけを持ち主にする。ついでに artifact の
-# 説明文も引く(read や list で触っただけの artifact は publish の tool_use を
-# 持たないので、ここで自然に外れる)。
+# session_id -> transcript のパス(cwd と repo 名を引くときの入口)
+{
+    awk -F"$SEP" -v sep="$SEP" '{ print $1 sep $3 }' "$T/art_urls"
+    awk -F"$SEP" -v sep="$SEP" '{ print $2 sep $3 }' "$T/pr_links"
+} | awk -F"$SEP" '!seen[$1]++' > "$T/sid_paths"
+
+# ---- artifact を publish したセッションを特定する --------------------------
+# tool_use.id と tool_result.tool_use_id で対応させ、実際に publish を走らせた
+# セッションだけを持ち主にする。ついでに説明文も引く(read や list で触っただけの
+# artifact は publish の tool_use を持たないので、ここで自然に外れる)。
 #
-# Why not URL に言及したセッション: 一覧を眺めた・レビューした・co を実行した
-# セッションの transcript にも URL は残る。言及だけで決めると sort 順の都合で
-# session_id の小さい無関係なセッションが行を攫っていく。
+# Why not URL に言及したセッション: 一覧を眺めた・co を実行したセッションの
+# transcript にも URL は残る。言及だけで決めると sort 順の都合で session_id の
+# 小さい無関係なセッションが行を攫っていく。
 #
-# Why not URL を含む全ファイルに jq: transcript は1本で数MBある。作成の痕跡が無い
-# ファイルを grep で先に落とすと、走査対象がおおむね半分になる。
-awk -F"$SEP" -v sep="$SEP" '!seen[$1 sep $3]++ { print $1 sep $3 }' "$T/urls" \
+# Why not URL を含む全ファイルに jq: transcript は1本で数MBある。publish の痕跡が
+# 無いファイルを grep で先に落とすと、走査対象がおおむね半分になる。
+awk -F"$SEP" -v sep="$SEP" '!seen[$1 sep $3]++ { print $1 sep $3 }' "$T/art_urls" \
     > "$T/scan_pairs"
 
-: > "$T/owners"      # url / session_id
-: > "$T/art_titles"  # url / 説明文
+: > "$T/art_meta"  # url / session_id / 説明文
 while IFS="$SEP" read -r sid f; do
     [ -f "$f" ] || continue
     # Why not "name":"Artifact": JSON の空白の入り方に依存する。絞り込みが目的なので
     # ツール名だけで足りる(外れても jq 側の条件で落ちる)。
-    grep -q -e 'gh pr create' -e '"Artifact"' "$f" 2>/dev/null || continue
+    grep -q '"Artifact"' "$f" 2>/dev/null || continue
     # Why not gsub で content 全体を整形: tool_result は巨大になりうる。URL だけ
     # scan で抜けば、同じ走査が桁で速くなる。
     jq -r --arg sep "$SEP" --arg sid "$sid" '
@@ -246,17 +274,14 @@ while IFS="$SEP" read -r sid f; do
         | .message.content[]?
         | if (.type == "tool_use" and .name == "Artifact"
               and ((.input.action // "publish") == "publish")) then
-              "T\($sep)\(.id // "")\($sep)art\($sep)\(
+              "T\($sep)\(.id // "")\($sep)\(
                   (.input.description // .input.title // .input.file_path // "")
                   | tostring | gsub("\\s+"; " ")
               )"
-          elif (.type == "tool_use" and .name == "Bash"
-                and ((.input.command // "") | test("gh pr create"))) then
-              "T\($sep)\(.id // "")\($sep)pr\($sep)"
           elif (.type == "tool_result" and .tool_use_id != null) then
               (.tool_use_id as $id
                | [ (.content | tostring)
-                   | scan("https://github\\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+|https://claude\\.ai/code/artifact/[0-9a-fA-F-]+")
+                   | scan("https://claude\\.ai/code/artifact/[0-9a-fA-F-]+")
                  ]
                | if length > 0 then
                      "R\($sep)\($id)\($sep)\($sid)\($sep)\(join(" "))"
@@ -264,20 +289,19 @@ while IFS="$SEP" read -r sid f; do
           else empty end
     ' "$f" 2>/dev/null
 done < "$T/scan_pairs" \
-    | awk -F"$SEP" -v sep="$SEP" -v ownerfile="$T/owners" -v titlefile="$T/art_titles" '
-        $1 == "T" { kind[$2] = $3; label[$2] = $4 }
-        # artifact は publish のたびに説明文が変わるので、後に来たもので上書きする。
+    | awk -F"$SEP" -v sep="$SEP" -v outfile="$T/art_meta" '
+        $1 == "T" { label[$2] = $3 }
+        # publish のたびに説明文が変わるので、後に来たもので上書きする。
         # 1セッション内では publish 順に並ぶので、これが最新の説明文になる。
-        $1 == "R" && ($2 in kind) {
+        $1 == "R" && ($2 in label) {
             n = split($4, us, " ")
             for (i = 1; i <= n; i++) {
                 owner[us[i]] = $3
-                if (kind[$2] == "art") arttitle[us[i]] = label[$2]
+                title[us[i]] = label[$2]
             }
         }
         END {
-            for (u in owner)    print u sep owner[u]    > ownerfile
-            for (u in arttitle) print u sep arttitle[u] > titlefile
+            for (u in owner) print u sep owner[u] sep title[u] > outfile
         }
     '
 
@@ -304,37 +328,27 @@ fi
 # 形式: kind / state / context / label / url / session_id
 : > "$T/rows"
 
-# PR: transcript の grep 結果と自分の open PR の交差を取る。
+# PR: pr-link の証跡と自分の open PR の交差を取る。
 #
-# Why not per-URL の gh pr view: この交差は鮮度や重複排除のためではなく、他人の PR を
-# 落とすためにある。PR レビューを依頼したセッションの transcript にはレビュー対象
-# (他人作)の URL が必ず出てくるので、--author=@me との交差でそれを除く。
+# Why not pr-link だけ: レコードには PR が今も open かも Draft かも入っていない。
+# 交差で state とタイトルを引くと同時に、閉じた PR が落ちる。
 #
 # 既知の限界: GitHub の検索インデックスは非同期なので、作られた直後の PR は
 # gh search prs に現れず、この交差から落ちる。塞ぐなら交差を置き換えるのではなく、
-# 漏れた URL だけを gh pr view で author 照合して足す。
+# 漏れた URL だけを gh pr view で引いて足す。
 #
-# session_id は作った証跡から引く。証跡が無い PR(手で作った・7日より前に作った等)は
-# 空のまま出す。ctrl-o は使えないが、行を落とすより無関係なセッションを開かない方がよい。
+# 既知の限界: 手で作った PR と、pr-link が無かった頃(2026-07 以前)の PR は出ない。
 awk -F"$SEP" -v sep="$SEP" '
     FILENAME == ARGV[1] { state[$1] = $2; repo[$1] = $3; title[$1] = $4; next }
-    FILENAME == ARGV[2] { owner[$1] = $2; next }
-    ($2 in state) {
-        if (seen[$2]++) next
-        print "pr" sep state[$2] sep repo[$2] sep title[$2] sep $2 sep owner[$2]
+    ($1 in state) {
+        print "pr" sep state[$1] sep repo[$1] sep title[$1] sep $1 sep $2
     }
-' "$T/live_prs" "$T/owners" "$T/urls" >> "$T/rows"
+' "$T/live_prs" "$T/pr_links" >> "$T/rows"
 
 # artifact: publish の説明文が引けたものだけを出す。
 awk -F"$SEP" -v sep="$SEP" '
-    FILENAME == ARGV[1] { title[$1] = $2; next }
-    FILENAME == ARGV[2] { owner[$1] = $2; next }
-    $2 ~ /claude\.ai\/code\/artifact\// {
-        if (!($2 in title)) next
-        if (seen[$2]++) next
-        print "artifact" sep "" sep "" sep title[$2] sep $2 sep owner[$2]
-    }
-' "$T/art_titles" "$T/owners" "$T/urls" >> "$T/rows"
+    { print "artifact" sep "" sep "" sep $3 sep $1 sep $2 }
+' "$T/art_meta" >> "$T/rows"
 
 # crit: セッション JSON は終了後も残るので、生きているものだけに絞る。
 port_open() {

--- a/bin/claude-outputs
+++ b/bin/claude-outputs
@@ -2,9 +2,10 @@
 # 並行して動かしている Claude セッションが「まだ開くべき成果物」として残しているものを
 # 1画面に集める。
 #
-# Why not 記録用の Stop hook: 3種すべて実行時のスキャンで実値が取れる。hook で記録層を
-# 持つと merge 済みの PR や終了した crit を生きているものと区別できず、hook 導入前の
-# セッションも拾えない。
+# Why not 記録用の Stop hook: 生きているかどうかは3種すべて実行時のスキャンで取れる。
+# 自前の hook で記録層を持つと merge 済みの PR や終了した crit を生きているものと
+# 区別できず、hook 導入前のセッションも拾えない。PR の紐付けだけは Claude Code 自身が
+# transcript に残すレコードを使うが、open かどうかは実行時に gh で確認する。
 #
 # bash 3.2(macOS 同梱)で動くよう連想配列を使わず、一時ファイルと awk で join する。
 
@@ -215,9 +216,14 @@ if [ -d "$PROJECTS_DIR" ]; then
 fi
 
 # ---- transcript から PR の証跡を抽出 --------------------------------------
-# gh pr create が成功すると Claude Code が transcript に pr-link レコードを書く
-# ({"type":"pr-link","sessionId":…,"prUrl":…})。作った本人が残す一次証跡なので、
-# tool_use と tool_result を突き合わせて持ち主を推定する必要がない。
+# Claude Code はセッションと PR を結び付けた時、transcript に pr-link レコードを書く
+# ({"type":"pr-link","sessionId":…,"prUrl":…})。gh pr create の成功はその契機の一つで、
+# 作成者のセッションには必ず入る。tool_use と tool_result を突き合わせる必要がない。
+#
+# ただし「作った」の証明ではない。作成後にその PR を触った別のセッションにも同じ
+# レコードが入る(実測: 1つの PR につき同一セッションで十数件、複数セッションから
+# 指されることもある)。作成者を採るために、URL ごとに最古のレコードを残す。作成者が
+# 走査窓の外にいる場合は、窓内で最も古く紐付いたセッションになる。
 #
 # Why not 全文に jq: transcript は1本で数MBある。grep で該当行だけ取り出して渡すと、
 # jq が読むのは1ファイルあたり数行で済む。
@@ -229,22 +235,26 @@ if [ -d "$PROJECTS_DIR" ]; then
             grep -E '"type": *"pr-link"' "$f" 2>/dev/null \
                 | jq -r --arg sep "$SEP" --arg path "$f" '
                     select(.type == "pr-link" and .prUrl != null and .sessionId != null)
-                    | [ .prUrl, .sessionId, (.timestamp // ""), $path ] | join($sep)
+                    # timestamp 欠けは最古扱いにしない。9999 は ISO8601 の年より後。
+                    | [ .prUrl, .sessionId, (.timestamp // "9999"), $path ] | join($sep)
                 ' 2>/dev/null
           done \
         | awk -F"$SEP" -v sep="$SEP" '
-            # 同じ PR に複数のレコードが付く(1つの PR につき十数件書かれる)。
-            # 同じ URL を複数のセッションが指す場合は、最後に紐付いたセッションを採る。
-            # timestamp は ISO8601 の Z 固定なので文字列比較で新しい方が勝つ。
-            $3 >= ts[$1] { ts[$1] = $3; sid[$1] = $2; path[$1] = $4 }
+            # timestamp は ISO8601 の Z 固定なので文字列比較で古い方が勝つ。
+            # 未登録の URL は ts が空文字なので、比較の前に in で分ける
+            # (空文字は常に最小になり、そのまま比べると全ての行が負ける)。
+            !($1 in ts) || $3 <= ts[$1] { ts[$1] = $3; sid[$1] = $2; path[$1] = $4 }
             END { for (u in sid) print u sep sid[u] sep path[u] }
-        ' > "$T/pr_links"
+        ' | sort -t"$SEP" -k2,2 -k1,1 > "$T/pr_links"
 fi
 
 # session_id -> transcript のパス(cwd と repo 名を引くときの入口)
+# pr-link はセッション自身の transcript にしか入らない。artifact 側は subagent の
+# transcript を指すことがあり、そちらの cwd は親と違う(worktree に入った後など)ので、
+# 同じ session_id なら pr-link 由来のパスを先に採る。
 {
-    awk -F"$SEP" -v sep="$SEP" '{ print $1 sep $3 }' "$T/art_urls"
     awk -F"$SEP" -v sep="$SEP" '{ print $2 sep $3 }' "$T/pr_links"
+    awk -F"$SEP" -v sep="$SEP" '{ print $1 sep $3 }' "$T/art_urls"
 } | awk -F"$SEP" '!seen[$1]++' > "$T/sid_paths"
 
 # ---- artifact を publish したセッションを特定する --------------------------
@@ -304,6 +314,9 @@ done < "$T/scan_pairs" \
             for (u in owner) print u sep owner[u] sep title[u] > outfile
         }
     '
+# awk の for-in はハッシュ順で、PR を1本足すだけで並びが変わる。同じセッションの
+# 成果物が固まるよう session_id で並べる(pr_links も同じキーで並べている)。
+sort -t"$SEP" -k2,2 -k1,1 "$T/art_meta" -o "$T/art_meta"
 
 # ---- PR の結果を回収 ------------------------------------------------------
 : > "$T/live_prs"
@@ -330,12 +343,13 @@ fi
 
 # PR: pr-link の証跡と自分の open PR の交差を取る。
 #
-# Why not pr-link だけ: レコードには PR が今も open かも Draft かも入っていない。
-# 交差で state とタイトルを引くと同時に、閉じた PR が落ちる。
+# Why not pr-link だけ: レコードには state もタイトルも入っていない。交差でそれを
+# 引くと同時に、閉じた PR と他人の PR が落ちる。レビューを依頼したセッションは
+# 他人の PR にも紐付くので、--author=@me との交差はここでも効いている。
 #
 # 既知の限界: GitHub の検索インデックスは非同期なので、作られた直後の PR は
 # gh search prs に現れず、この交差から落ちる。塞ぐなら交差を置き換えるのではなく、
-# 漏れた URL だけを gh pr view で引いて足す。
+# 漏れた URL だけを gh pr view で author 照合して足す。
 #
 # 既知の限界: 手で作った PR と、pr-link が無かった頃(2026-07 以前)の PR は出ない。
 awk -F"$SEP" -v sep="$SEP" '


### PR DESCRIPTION
## Summary
- transcript に出た PR URL を拾う方式では、`co` や `gh search prs` を実行しただけのセッションが無関係な PR を一覧に持ち込んでいた
- Claude Code が `gh pr create` 時に transcript へ書く pr-link レコードを起点にし、PR ごとに最古のレコードで作成セッションへ帰属させる
- ctrl-o が PR と無関係なセッションへ飛ぶ誤りが消える
