### PR TITLE
空白を含むパスのセッションログを読めるようにする

### DIFF
--- a/bin/tests/test-weekly-feedback-extract.sh
+++ b/bin/tests/test-weekly-feedback-extract.sh
@@ -16,7 +16,8 @@ D1=$(date -j -v-3d -f '%Y-%m-%d' "$TODAY" '+%Y-%m-%d')
 D2=$(date -j -v-2d -f '%Y-%m-%d' "$TODAY" '+%Y-%m-%d')
 D3=$(date -j -v-1d -f '%Y-%m-%d' "$TODAY" '+%Y-%m-%d')
 
-VAULT="$WORK/vault"
+# 実運用の Vault パスは空白を含む(Obsidian Vault)。単語分割の回帰を踏むためここも空白入りにする
+VAULT="$WORK/Obsidian Vault"
 for d in "$D1" "$D2" "$D3"; do
     mkdir -p "$VAULT/03_Claude/$d"
     printf 'session log for %s\n' "$d" > "$VAULT/03_Claude/$d/proj.md"
@@ -26,10 +27,12 @@ done
 export CLAUDE_PROJECTS_DIR="$WORK/no-projects"
 export OBSIDIAN_VAULT="$VAULT"
 
+# stub は受け取った stdin を残す。空入力でも「抽出成功」に見えてしまう事故を検知する
+export STUB_STDIN="$WORK/stub-stdin"
 STUB="$WORK/stub-claude"
 cat > "$STUB" <<'STUBEOF'
 #!/bin/bash
-cat > /dev/null
+cat >> "$STUB_STDIN"
 if [ -n "${STUB_FAIL:-}" ]; then
     echo "stub failure" >&2
     exit 1
@@ -67,6 +70,12 @@ check "処理した日の見出しが3つある" "3" "$(grep -c '^## 20' "$OUT2"
 
 WEEK_D1=$(date -j -f '%Y-%m-%d' "$D1" '+%G-W%V')
 check "ISO週でファイル名が決まる" "0" "$(test -f "$OUT2/$WEEK_D1.md" && echo 0 || echo 1)"
+
+# 空白入りパスのセッションログが実際に claude へ渡っているか(単語分割の回帰)
+check "空白を含むパスのセッションログが入力に載る" "3" \
+    "$(grep -c '^===== SESSION: proj.md =====$' "$STUB_STDIN" 2>/dev/null || echo 0)"
+check "セッションログの中身が入力に載る" "3" \
+    "$(grep -c '^session log for 20' "$STUB_STDIN" 2>/dev/null || echo 0)"
 
 # --- マーカーがあれば処理済みの日を二重に追記しない ---
 BEFORE=$(cat "$OUT2"/*.md | wc -c | tr -d ' ')

--- a/bin/weekly-feedback-extract
+++ b/bin/weekly-feedback-extract
@@ -173,18 +173,28 @@ for d in $DATES; do
     fi
 
     PAYLOAD_FILE=$(mktemp) || { warn "mktemp failed"; break; }
+    # Why not for f in $files: Vault のパスは空白を含む(Obsidian Vault)ので単語分割で
+    # パスが割れる。read なら行単位で読むので割れない。
     {
-        for f in $session_files; do
+        printf '%s\n' "$session_files" | while IFS= read -r f; do
+            [ -n "$f" ] || continue
             printf '\n===== SESSION: %s =====\n' "$(basename "$f")"
             cat "$f"
         done
-        for f in $memory_files; do
+        printf '%s\n' "$memory_files" | while IFS= read -r f; do
+            [ -n "$f" ] || continue
             printf '\n===== MEMORY: %s =====\n' "$(basename "$f")"
             cat "$f"
         done
-    } > "$PAYLOAD_FILE" 2>/dev/null
+    } > "$PAYLOAD_FILE"
 
     size=$(wc -c < "$PAYLOAD_FILE" | tr -d ' ')
+    # 読めたバイト数を見ないと、cat が全部失敗しても「空の入力で抽出成功」になる
+    if [ "$size" -eq 0 ]; then
+        warn "$d: 入力を1バイトも読めなかった。マーカーは進めない"
+        rm -f "$PAYLOAD_FILE"
+        break
+    fi
     if [ "$size" -gt "$MAX_BYTES" ]; then
         warn "$d: 入力が ${size}B なので先頭 ${MAX_BYTES}B に切り詰める"
         TRUNC=$(mktemp)


### PR DESCRIPTION
## Summary
- Vault のパスが `Obsidian Vault` と空白を含むため単語分割でパスが割れ、セッションログが1件も読まれていなかった。stderr を捨てていたので成功として記録されていた。
- 読めたバイト数が0の日はマーカーを進めない。何も読めなかった実行は成功ではない。
- テストの Vault パスに空白を入れ、stub が stdin を保持して実際に届いたかを検証する(旧コードで落ちることを確認済み)。