### PR TITLE
fix: guard-worktree-path の判定漏れを塞ぐ

### DIFF
--- a/.github/workflows/hooks-tests.yml
+++ b/.github/workflows/hooks-tests.yml
@@ -37,7 +37,9 @@ jobs:
       - name: shellcheck
         # the macOS runner image does not ship shellcheck
         if: runner.os == 'Linux'
-        run: shellcheck -S warning claude/hooks/*.sh claude/hooks/tests/*.sh claude/statusline.sh bin/*
+        # bin/ holds extensionless commands next to a tests/ directory, and a
+        # directory handed to shellcheck fails the step
+        run: shellcheck -S warning claude/hooks/*.sh claude/hooks/tests/*.sh claude/statusline.sh $(find bin -maxdepth 1 -type f)
       - name: hook tests
         run: |
           bash --version | head -1

--- a/claude/hooks/guard-worktree-path.sh
+++ b/claude/hooks/guard-worktree-path.sh
@@ -10,9 +10,36 @@ set -uo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
+# Heredoc bodies are document text, not commands: writing an example path into
+# a file must not trip the guard. The accepted cost is that a body fed to an
+# interpreter (bash <<EOF) is not inspected either — this is an accident guard.
+# A python failure leaves SCAN empty and falls back to the raw command, so the
+# scan errs toward inspecting too much rather than too little.
+SCAN=$(printf '%s' "$COMMAND" | python3 -c '
+import re, sys
+lines = sys.stdin.read().split("\n")
+# (?<!<) and (?!<) keep here-strings (<<< word) from being read as a tag.
+tag_re = re.compile(r"(?<!<)<<(-?)[ \t]*(?!<)[\x27\"\\]?([A-Za-z_][A-Za-z0-9_]*)[\x27\"]?")
+out = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    i += 1
+    out.append(line)
+    for dash, tag in tag_re.findall(line):
+        while i < len(lines):
+            body = lines[i]
+            i += 1
+            # <<- strips leading tabs from the terminator, plain << does not.
+            if (body.lstrip("\t") if dash else body) == tag:
+                break
+sys.stdout.write("\n".join(out))
+' 2>/dev/null)
+[ -z "$SCAN" ] && SCAN="$COMMAND"
+
 # Only inspect `git worktree add` (any form: `git -C <dir> worktree add`,
 # `cd <dir> && git worktree add`, etc. — match the `worktree add` token pair).
-echo "$COMMAND" | grep -qE 'worktree[[:space:]]+add' || exit 0
+echo "$SCAN" | grep -qE 'worktree[[:space:]]+add' || exit 0
 
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 CWD="${CWD:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
@@ -20,9 +47,13 @@ CWD="${CWD:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
 [ -z "$ROOT" ] && exit 0   # not in a git repo, leave it alone
 
-# Extract the worktree path: drop everything up to "add", then take the first
-# positional token (skipping option flags and their values) via shlex.
-TARGET=$(echo "$COMMAND" \
+# Extract the worktree path: keep the first line that carries the invocation
+# (other lines of a multi-line command would otherwise donate the first token),
+# drop everything up to "add", then take the first positional token (skipping
+# option flags and their values) via shlex.
+TARGET=$(echo "$SCAN" \
+  | grep -E 'worktree[[:space:]]+add' \
+  | head -1 \
   | sed -E 's/.*worktree[[:space:]]+add[[:space:]]*//' \
   | python3 -c '
 import sys, shlex

--- a/claude/hooks/guard-worktree-path.sh
+++ b/claude/hooks/guard-worktree-path.sh
@@ -4,22 +4,30 @@
 # silently reset to the launch root, leaking artifacts (.venv, uv.lock, ...) to
 # the wrong tree. Steer to an in-repo path such as .claude/worktrees/<branch>.
 # Exit code 2 blocks the tool execution and shows stderr to Claude.
+#
+# Accident guard, not an adversarial boundary: parsing is heuristic, and a
+# heredoc body fed to an interpreter (bash <<EOF) is never inspected.
 
 set -uo pipefail
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
+# Only inspect `git worktree add` (any form: `git -C <dir> worktree add`,
+# `cd <dir> && git worktree add`, etc. — match the `worktree add` token pair).
+# Heredoc stripping below only ever removes lines, so gating on the raw command
+# first is safe and keeps python off the path of every other Bash call.
+echo "$COMMAND" | grep -qE 'worktree[[:space:]]+add' || exit 0
+
 # Heredoc bodies are document text, not commands: writing an example path into
-# a file must not trip the guard. The accepted cost is that a body fed to an
-# interpreter (bash <<EOF) is not inspected either — this is an accident guard.
-# A python failure leaves SCAN empty and falls back to the raw command, so the
-# scan errs toward inspecting too much rather than too little.
+# a file must not trip the guard. A python failure leaves SCAN empty and falls
+# back to the raw command, so the scan errs toward inspecting too much rather
+# than too little.
 SCAN=$(printf '%s' "$COMMAND" | python3 -c '
 import re, sys
 lines = sys.stdin.read().split("\n")
 # (?<!<) and (?!<) keep here-strings (<<< word) from being read as a tag.
-tag_re = re.compile(r"(?<!<)<<(-?)[ \t]*(?!<)[\x27\"\\]?([A-Za-z_][A-Za-z0-9_]*)[\x27\"]?")
+tag_re = re.compile(r"(?<!<)<<(-?)[ \t]*(?!<)[\x27\"\\]?([A-Za-z0-9_][A-Za-z0-9_.-]*)[\x27\"]?")
 out = []
 i = 0
 while i < len(lines):
@@ -27,19 +35,22 @@ while i < len(lines):
     i += 1
     out.append(line)
     for dash, tag in tag_re.findall(line):
+        start = i
+        closed = False
         while i < len(lines):
             body = lines[i]
             i += 1
             # <<- strips leading tabs from the terminator, plain << does not.
             if (body.lstrip("\t") if dash else body) == tag:
+                closed = True
                 break
+        if not closed:
+            # Nothing terminated it, so the "<<" was probably a shift operator
+            # or lived inside a quoted string. Put the swallowed lines back.
+            out.extend(lines[start:])
 sys.stdout.write("\n".join(out))
 ' 2>/dev/null)
 [ -z "$SCAN" ] && SCAN="$COMMAND"
-
-# Only inspect `git worktree add` (any form: `git -C <dir> worktree add`,
-# `cd <dir> && git worktree add`, etc. — match the `worktree add` token pair).
-echo "$SCAN" | grep -qE 'worktree[[:space:]]+add' || exit 0
 
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 CWD="${CWD:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
@@ -47,21 +58,21 @@ CWD="${CWD:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
 [ -z "$ROOT" ] && exit 0   # not in a git repo, leave it alone
 
-# Extract the worktree path: keep the first line that carries the invocation
-# (other lines of a multi-line command would otherwise donate the first token),
-# drop everything up to "add", then take the first positional token (skipping
-# option flags and their values) via shlex.
-TARGET=$(echo "$SCAN" \
-  | grep -E 'worktree[[:space:]]+add' \
-  | head -1 \
-  | sed -E 's/.*worktree[[:space:]]+add[[:space:]]*//' \
-  | python3 -c '
+# Judge every line that carries an invocation: an earlier benign mention must
+# not mask a later one. Other lines of a multi-line command are kept out of the
+# extraction, or they would donate their own first token as the target.
+while IFS= read -r LINE; do
+  # Extract the worktree path: drop everything up to "add", then take the first
+  # positional token (skipping option flags and their values) via shlex.
+  TARGET=$(printf '%s' "$LINE" \
+    | sed -E 's/.*worktree[[:space:]]+add[[:space:]]*//' \
+    | python3 -c '
 import sys, shlex
 try:
     toks = shlex.split(sys.stdin.read())
 except Exception:
     sys.exit(0)
-valopts = {"-b", "-B", "--reason", "--orphan"}   # flags that consume the next token
+valopts = {"-b", "-B", "--reason"}   # flags that consume the next token
 i = 0
 while i < len(toks):
     t = toks[i]
@@ -72,20 +83,22 @@ while i < len(toks):
     print(t); break
 ' 2>/dev/null)
 
-[ -z "$TARGET" ] && exit 0
+  [ -z "$TARGET" ] && continue
 
-# Resolve TARGET against CWD and test whether it lands inside ROOT.
-# normpath works without the path existing yet.
-INSIDE=$(python3 -c '
+  # Resolve TARGET against CWD and test whether it lands inside ROOT.
+  # normpath works without the path existing yet.
+  INSIDE=$(python3 -c '
 import os, sys
 cwd, target, root = sys.argv[1], sys.argv[2], sys.argv[3]
+target = os.path.expanduser(target)
 p = target if os.path.isabs(target) else os.path.join(cwd, target)
 p = os.path.normpath(p)
 root = os.path.normpath(root)
 print("yes" if (p == root or p.startswith(root + os.sep)) else "no")
 ' "$CWD" "$TARGET" "$ROOT" 2>/dev/null)
 
-if [ "$INSIDE" = "no" ]; then
+  [ "$INSIDE" = "no" ] || continue
+
   cat >&2 <<EOF
 BLOCKED: worktree をリポジトリ外に作成しようとしています ($TARGET)。
 リポジトリ外(兄弟階層/絶対パス)の worktree は Bash の cwd が起動ルートに戻り、
@@ -93,6 +106,6 @@ BLOCKED: worktree をリポジトリ外に作成しようとしています ($TA
 リポジトリ内に作成してください。例: git worktree add .claude/worktrees/<branch>
 EOF
   exit 2
-fi
+done < <(echo "$SCAN" | grep -E 'worktree[[:space:]]+add')
 
 exit 0

--- a/claude/hooks/tests/test-guard-worktree-path.sh
+++ b/claude/hooks/tests/test-guard-worktree-path.sh
@@ -37,6 +37,8 @@ run_case() {
 run_case block 'git worktree add ../x'
 run_case block "git worktree add $WORK/outside"
 run_case block 'git worktree add "../x with space"'
+run_case block 'git worktree add ~/outside'
+run_case block 'git worktree add --orphan ../x'
 
 # --- in-repo target, and subcommands other than add, pass ---
 run_case pass 'git worktree add .claude/worktrees/x'
@@ -50,6 +52,8 @@ run_case pass $'cat > docs/x.md <<\'EOF\'\ngit worktree add ../x\nEOF'
 run_case pass $'cat > docs/x.md <<"EOF"\ngit worktree add ../x\nEOF'
 run_case pass $'cat > docs/x.md <<\\EOF\ngit worktree add ../x\nEOF'
 run_case pass $'cat > docs/x.md <<-EOF\n\tgit worktree add ../x\n\tEOF'
+run_case pass $'cat > docs/x.md <<1EOF\ngit worktree add ../x\n1EOF'
+run_case pass $'cat > docs/x.md <<\'PY-DOC\'\ngit worktree add ../x\nPY-DOC'
 run_case pass $'cat <<A > a.md && cat <<B > b.md\ngit worktree add ../a\nA\ngit worktree add ../b\nB'
 
 # --- an invocation outside a heredoc body still blocks ---
@@ -57,6 +61,14 @@ run_case block $'cat > docs/x.md <<EOF\nhello\nEOF\ngit worktree add ../x'
 run_case block $'echo hi\ngit worktree add ../x'
 # a here-string is not a heredoc: it must not swallow the following lines
 run_case block $'cat <<< hello\ngit worktree add ../x'
+run_case block 'cat <<< hello && git worktree add ../x'
+# an unterminated "<<" is a shift operator or quoted text, not a heredoc opener
+run_case block $'echo "a << b"\ngit worktree add ../x'
+run_case block $'echo $((a << b))\ngit worktree add ../x'
+
+# --- every candidate line is judged, not only the first ---
+run_case block $'git worktree add .claude/worktrees/a\ngit worktree add ../x'
+run_case block $'echo "例: git worktree add .claude/worktrees/a"\ngit worktree add ../x'
 
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/claude/hooks/tests/test-guard-worktree-path.sh
+++ b/claude/hooks/tests/test-guard-worktree-path.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Table-driven tests for guard-worktree-path.sh.
+# Usage: bash claude/hooks/tests/test-guard-worktree-path.sh
+set -uo pipefail
+
+# Hermetic against the machine's git config (init.defaultBranch etc.)
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/guard-worktree-path.sh"
+PASS=0
+FAIL=0
+
+# -P: the hook compares against `rev-parse --show-toplevel`, which is physical;
+# macOS mktemp hands back a /var -> /private/var symlink.
+WORK=$(cd "$(mktemp -d)" && pwd -P)
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/repo"
+git init -q -b main "$REPO"
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+run_case() {
+  local expect="$1" cmd="$2"
+  jq -n --arg c "$cmd" --arg d "$REPO" '{tool_input: {command: $c}, cwd: $d}' | bash "$HOOK" >/dev/null 2>&1
+  local code=$?
+  local got="pass"
+  [ "$code" -eq 2 ] && got="block"
+  if [ "$got" = "$expect" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL [expect=$expect got=$got]: $cmd"
+  fi
+}
+
+# --- target outside the repository root is blocked ---
+run_case block 'git worktree add ../x'
+run_case block "git worktree add $WORK/outside"
+run_case block 'git worktree add "../x with space"'
+
+# --- in-repo target, and subcommands other than add, pass ---
+run_case pass 'git worktree add .claude/worktrees/x'
+run_case pass 'git worktree add -b feat/x .claude/worktrees/x'
+run_case pass 'git worktree list'
+run_case pass 'git worktree remove ../x'
+
+# --- heredoc bodies are document text, not commands ---
+run_case pass $'cat > docs/x.md <<EOF\ngit worktree add ../x\nEOF'
+run_case pass $'cat > docs/x.md <<\'EOF\'\ngit worktree add ../x\nEOF'
+run_case pass $'cat > docs/x.md <<"EOF"\ngit worktree add ../x\nEOF'
+run_case pass $'cat > docs/x.md <<\\EOF\ngit worktree add ../x\nEOF'
+run_case pass $'cat > docs/x.md <<-EOF\n\tgit worktree add ../x\n\tEOF'
+run_case pass $'cat <<A > a.md && cat <<B > b.md\ngit worktree add ../a\nA\ngit worktree add ../b\nB'
+
+# --- an invocation outside a heredoc body still blocks ---
+run_case block $'cat > docs/x.md <<EOF\nhello\nEOF\ngit worktree add ../x'
+run_case block $'echo hi\ngit worktree add ../x'
+# a here-string is not a heredoc: it must not swallow the following lines
+run_case block $'cat <<< hello\ngit worktree add ../x'
+
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- 複数行コマンドでは判定対象のトークンを取り違え、リポジトリ外への `git worktree add` が素通りしていた
- 抽出を直すと文書中の例示パスが本物として扱われるため、ヒアドキュメント本文を走査対象から外した
- 同じく素通りだった `~` 展開・`--orphan`・未終端の `<<` も塞いだ
