### PR TITLE
同じ日の抽出を追記ではなく差し替えにする

### DIFF
--- a/bin/tests/test-weekly-feedback-extract.sh
+++ b/bin/tests/test-weekly-feedback-extract.sh
@@ -83,6 +83,26 @@ WEEKLY_FEEDBACK_DIR="$OUT2" bash "$SCRIPT" >/dev/null 2>&1
 AFTER=$(cat "$OUT2"/*.md | wc -c | tr -d ' ')
 check "再実行しても追記されない" "$BEFORE" "$AFTER"
 
+# --- --since はマーカーを無視するので、処理済みの日を再度渡しても重複しない ---
+WEEKLY_FEEDBACK_DIR="$OUT2" bash "$SCRIPT" --since "$D1" >/dev/null 2>&1
+check "--since で再処理しても日の見出しは増えない" "3" \
+    "$(grep -c '^## 20' "$OUT2"/*.md 2>/dev/null | awk -F: '{s+=$NF} END {print s+0}')"
+check "--since で再処理しても内容は1日1回ぶん" "3" \
+    "$(grep -c '^- stub$' "$OUT2"/*.md 2>/dev/null | awk -F: '{s+=$NF} END {print s+0}')"
+
+# --- 進行中の当日はマーカーを進めない(あとで積まれるログを取りこぼさない) ---
+OUT5="$WORK/out5"
+mkdir -p "$VAULT/03_Claude/$TODAY"
+printf 'session log for %s\n' "$TODAY" > "$VAULT/03_Claude/$TODAY/proj.md"
+WEEKLY_FEEDBACK_DIR="$OUT5" bash "$SCRIPT" --since "$TODAY" >/dev/null 2>&1
+check "当日を処理してもマーカーは進めない" "<none>" "$(marker_of "$OUT5")"
+WEEK_TODAY=$(date -j -f '%Y-%m-%d' "$TODAY" '+%G-W%V')
+check "当日の抽出結果は書かれている" "1" \
+    "$(grep -c "^## $TODAY\$" "$OUT5/$WEEK_TODAY.md" 2>/dev/null || echo 0)"
+WEEKLY_FEEDBACK_DIR="$OUT5" bash "$SCRIPT" --since "$TODAY" >/dev/null 2>&1
+check "当日を再処理しても重複しない" "1" \
+    "$(grep -c "^## $TODAY\$" "$OUT5/$WEEK_TODAY.md" 2>/dev/null || echo 0)"
+
 # --- 抽出が失敗したらマーカーを進めない(次回その日から再開する) ---
 OUT3="$WORK/out3"
 STUB_FAIL=1 WEEKLY_FEEDBACK_DIR="$OUT3" bash "$SCRIPT" --since "$D1" >/dev/null 2>&1

--- a/bin/weekly-feedback-extract
+++ b/bin/weekly-feedback-extract
@@ -224,12 +224,29 @@ for d in $DATES; do
             printf '> weekly-feedback の Step 2 を書き終えるまで開かないこと。\n'
         } > "$WEEK_FILE"
     fi
+    # 同じ日を2度書かない。--since はマーカーを無視するし、当日は完了までに
+    # 何度も処理されるので、追記ではなくその日の節ごと差し替える
+    if grep -q "^## $d\$" "$WEEK_FILE"; then
+        REWRITE=$(mktemp)
+        awk -v target="## $d" '
+            $0 == target { skip = 1; next }
+            /^## 20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/ { skip = 0 }
+            !skip { print }
+        ' "$WEEK_FILE" > "$REWRITE"
+        if ! mv -f "$REWRITE" "$WEEK_FILE"; then
+            warn "$d: 既存の節を差し替えられなかった"
+            rm -f "$REWRITE"
+            break
+        fi
+    fi
     {
         printf '\n## %s\n\n' "$d"
         printf '%s\n' "$OUT"
     } >> "$WEEK_FILE"
 
-    printf '%s\n' "$d" > "$MARKER"
+    # 当日はまだ作業が続くのでマーカーを進めない。進めると、その後に積まれた
+    # ログが二度と抽出されない
+    [ "$d" \< "$TODAY" ] && printf '%s\n' "$d" > "$MARKER"
     processed=$((processed + 1))
     printf '[weekly-feedback] %s -> %s\n' "$d" "$WEEK_FILE"
 done


### PR DESCRIPTION
## Summary
- `--since` はマーカーを無視するため、中断した実行を再開すると処理済みの日を二重に書いていた。
- 進行中の当日を「処理済み」として記録していたため、その後に積まれたログが二度と抽出されなかった。
- 日の節を差し替える形にし、当日はマーカーを進めない。当日は何度でも走らせて最新版に更新できる。